### PR TITLE
Add CODEOWNERS for required review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @maciej-makowski


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` — all files owned by @maciej-makowski
- Branch protection updated: requires 1 approval from code owner, stale reviews dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)