### PR TITLE
Add dev environment startup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-e2e migrate revision lint build run clean test-env-up test-env-down fetch classify reclassify
+.PHONY: test test-e2e migrate revision lint lint-fix build run clean test-env-up test-env-down fetch classify reclassify dev
 
 test:
 	uv run pytest tests/integration/ -v
@@ -45,3 +45,6 @@ classify:
 
 reclassify:
 	uv run python -m src.scrapers.scheduler reclassify $(company)
+
+dev:
+	./scripts/dev.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The web container auto-runs database migrations on startup. The scraper fetches 
 | PostgreSQL | 5433  | Mapped to 5433 to avoid conflicts  |
 | Ollama     | 11435 | Mapped to 11435 to avoid conflicts |
 
+### Data Persistence
+
+Database data is stored in a named Podman volume (`are-they-hiring_arethey-db-data`) and survives container restarts. To wipe the database and start fresh:
+
+```bash
+podman-compose --podman-path ./scripts/podman-remote.sh -f podman-compose.dev.yml down -v
+```
+
 ### Podman Remote (Toolbox/Container Environments)
 
 If you're running inside a toolbox or container where `podman` needs `--remote`, use the wrapper:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+PODMAN="podman --remote"
+COMPOSE="podman-compose --podman-path ./scripts/podman-remote.sh -f podman-compose.dev.yml"
+
+echo "Starting dev environment..."
+$COMPOSE up -d
+
+echo ""
+echo "Services running:"
+$COMPOSE ps
+echo ""
+echo "Web UI: http://localhost:8000"
+echo "Press Ctrl+C to stop all services"
+echo ""
+
+LOG_PIDS=()
+
+cleanup() {
+    echo ""
+    echo "Stopping log streams..."
+    for pid in "${LOG_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    echo "Stopping dev environment..."
+    $COMPOSE down
+}
+trap cleanup EXIT
+
+# Follow logs from each container in background, prefixed with container name
+for container in $($PODMAN ps --filter "name=are-they-hiring_" --format "{{.Names}}"); do
+    $PODMAN logs -f "$container" 2>&1 | sed "s/^/[$container] /" &
+    LOG_PIDS+=($!)
+done
+
+# Wait for Ctrl+C
+wait


### PR DESCRIPTION
## Summary
- `scripts/dev.sh`: starts all services, streams logs prefixed with container names, stops everything on Ctrl+C
- `make dev` target added to Makefile

## Test plan
- [x] `make dev` starts all 4 services and shows logs
- [x] Ctrl+C cleanly stops all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)