### PR TITLE
Replace bar chart with 30-day calendar widget

### DIFF
--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -56,25 +56,42 @@ async def get_daily_counts(
     session: AsyncSession,
     days: int = 30,
 ) -> list[dict]:
-    """Get posting counts per day for the last N days.
+    """Get posting counts and scrape status per day for the last N days.
 
-    Returns list of dicts with 'date' and 'count' keys, ordered by date ascending.
-    A posting is counted on a day if first_seen_date <= day <= last_seen_date.
+    Returns list of dicts ordered by date ascending:
+      - date: the date
+      - count: number of SWE postings active on that day
+      - scraped: whether at least one successful scrape ran that day
     """
     today = date.today()
     results = []
 
     for i in range(days - 1, -1, -1):
         d = today - timedelta(days=i)
-        result = await session.execute(
+
+        # Count SWE postings active on this day
+        count_result = await session.execute(
             select(func.count(JobPosting.id)).where(
                 JobPosting.first_seen_date <= d,
                 JobPosting.last_seen_date >= d,
                 JobPosting.is_software_engineering == True,
             )
         )
-        count = result.scalar()
-        results.append({"date": d, "count": count})
+        count = count_result.scalar()
+
+        # Check if any successful scrape ran on this day
+        day_start = datetime.combine(d, datetime.min.time(), tzinfo=UTC)
+        day_end = datetime.combine(d + timedelta(days=1), datetime.min.time(), tzinfo=UTC)
+        scrape_result = await session.execute(
+            select(func.count(ScrapeRun.id)).where(
+                ScrapeRun.status == "success",
+                ScrapeRun.started_at >= day_start,
+                ScrapeRun.started_at < day_end,
+            )
+        )
+        scraped = (scrape_result.scalar() or 0) > 0
+
+        results.append({"date": d, "count": count, "scraped": scraped})
 
     return results
 

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -115,6 +115,18 @@ async def get_postings_for_date(
     return list(result.scalars().all())
 
 
+async def get_scrape_runs_for_date(session: AsyncSession, target_date: date) -> list[ScrapeRun]:
+    """Get all scrape runs that started on a given date."""
+    day_start = datetime.combine(target_date, datetime.min.time(), tzinfo=UTC)
+    day_end = datetime.combine(target_date + timedelta(days=1), datetime.min.time(), tzinfo=UTC)
+    result = await session.execute(
+        select(ScrapeRun)
+        .where(ScrapeRun.started_at >= day_start, ScrapeRun.started_at < day_end)
+        .order_by(ScrapeRun.started_at.desc())
+    )
+    return list(result.scalars().all())
+
+
 async def get_yesterday_count(session: AsyncSession) -> int:
     """Get total software engineering posting count for yesterday."""
     yesterday = date.today() - timedelta(days=1)

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -102,11 +102,16 @@ def create_app(db_session_override=None) -> FastAPI:
 
     @app.get("/day/{target_date}")
     async def day_detail(request: Request, target_date: str, session: AsyncSession = Depends(get_session)):
+        from src.db.queries import get_scrape_runs_for_date
+
         parsed_date = date.fromisoformat(target_date)
         postings = await get_postings_for_date(session, parsed_date)
+        scrape_runs = await get_scrape_runs_for_date(session, parsed_date)
         by_company: dict[str, list] = {}
         for p in postings:
             by_company.setdefault(p.company, []).append(p)
+
+        scraped = len(scrape_runs) > 0
         return templates.TemplateResponse(
             "day_detail.html",
             {
@@ -115,6 +120,8 @@ def create_app(db_session_override=None) -> FastAPI:
                 "postings": postings,
                 "by_company": by_company,
                 "total": len(postings),
+                "scraped": scraped,
+                "scrape_runs": scrape_runs,
             },
         )
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -41,9 +41,36 @@ def create_app(db_session_override=None) -> FastAPI:
         today = date.today()
         summary = await get_todays_scrape_summary(session)
         raw_counts = await get_daily_counts(session)
-        daily_counts = [
-            {"date": d["date"].isoformat(), "count": d["count"], "scraped": d["scraped"]} for d in raw_counts
-        ]
+        # Build a lookup by date string
+        day_data = {
+            d["date"].isoformat(): {"date": d["date"].isoformat(), "count": d["count"], "scraped": d["scraped"]}
+            for d in raw_counts
+        }
+
+        # Build calendar weeks (Mon=0 ... Sun=6)
+        from datetime import timedelta
+
+        current_month = today.month
+        start = today - timedelta(days=29)
+        # Pad to start of the week (Monday)
+        start_weekday = start.weekday()  # 0=Mon
+
+        calendar_weeks = []
+        week = [None] * start_weekday  # pad leading days
+        d = start
+        while d <= today:
+            iso = d.isoformat()
+            entry = day_data.get(iso, {"date": iso, "count": 0, "scraped": False})
+            entry["in_current_month"] = d.month == current_month
+            entry["day_num"] = d.day
+            entry["weekday"] = d.strftime("%a")
+            week.append(entry)
+            if len(week) == 7:
+                calendar_weeks.append(week)
+                week = []
+            d += timedelta(days=1)
+        if week:
+            calendar_weeks.append(week)
 
         # Determine display state:
         # "yes"     - at least one scraper finished and found SWE postings
@@ -65,7 +92,7 @@ def create_app(db_session_override=None) -> FastAPI:
                 "request": request,
                 "state": state,
                 "count": summary["posting_count"],
-                "daily_counts": daily_counts,
+                "calendar_weeks": calendar_weeks,
                 "months": months,
                 "days_remainder": days_r,
                 "total_days": delta.days,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -41,7 +41,9 @@ def create_app(db_session_override=None) -> FastAPI:
         today = date.today()
         summary = await get_todays_scrape_summary(session)
         raw_counts = await get_daily_counts(session)
-        daily_counts = [{"date": d["date"].isoformat(), "count": d["count"]} for d in raw_counts]
+        daily_counts = [
+            {"date": d["date"].isoformat(), "count": d["count"], "scraped": d["scraped"]} for d in raw_counts
+        ]
 
         # Determine display state:
         # "yes"     - at least one scraper finished and found SWE postings

--- a/src/web/static/app.js
+++ b/src/web/static/app.js
@@ -14,74 +14,6 @@ function updateCounter() {
 }
 setInterval(updateCounter, 60000);
 
-// Chart.js bar chart
-function initChart() {
-    const canvas = document.getElementById('postsChart');
-    if (!canvas || typeof dailyCounts === 'undefined') return;
-
-    const labels = dailyCounts.map(d => d.date);
-    const data = dailyCounts.map(d => d.count);
-
-    // Plugin: draw warning triangle for zero-count days
-    const warningPlugin = {
-        id: 'warningTriangle',
-        afterDatasetsDraw(chart) {
-            const { ctx } = chart;
-            const meta = chart.getDatasetMeta(0);
-            meta.data.forEach((bar, i) => {
-                if (data[i] === 0) {
-                    const x = bar.x;
-                    const y = chart.scales.y.getPixelForValue(0) - 10;
-                    ctx.save();
-                    ctx.fillStyle = '#f59e0b';
-                    ctx.font = '16px sans-serif';
-                    ctx.textAlign = 'center';
-                    ctx.fillText('\u26A0', x, y);
-                    ctx.restore();
-                }
-            });
-        }
-    };
-
-    new Chart(canvas, {
-        type: 'bar',
-        data: {
-            labels: labels,
-            datasets: [{
-                label: 'SWE Postings',
-                data: data,
-                backgroundColor: data.map(v => v > 0 ? 'rgba(34, 197, 94, 0.7)' : 'rgba(239, 68, 68, 0.3)'),
-                borderColor: data.map(v => v > 0 ? '#22c55e' : '#ef4444'),
-                borderWidth: 1,
-            }]
-        },
-        options: {
-            responsive: true,
-            onClick(e, elements) {
-                if (elements.length > 0) {
-                    const idx = elements[0].index;
-                    window.location.href = '/day/' + labels[idx];
-                }
-            },
-            scales: {
-                x: {
-                    ticks: { color: '#888', maxRotation: 45 },
-                    grid: { color: '#222' }
-                },
-                y: {
-                    beginAtZero: true,
-                    ticks: { color: '#888' },
-                    grid: { color: '#222' }
-                }
-            },
-            plugins: {
-                legend: { labels: { color: '#ccc' } }
-            }
-        },
-        plugins: [warningPlugin]
-    });
-}
-
 // Sound + effects
 function playCelebrate() {
     try {
@@ -102,7 +34,6 @@ function playAlarm() {
 
 // Auto-confetti on YES state
 document.addEventListener('DOMContentLoaded', () => {
-    initChart();
     if (document.querySelector('.hero-yes') && typeof confetti === 'function') {
         confetti({ particleCount: 100, spread: 60, origin: { y: 0.6 } });
     }

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -38,22 +38,23 @@ main {
 
 /* Counter section */
 .counter {
-    margin-bottom: 2rem;
-    font-size: 1.1rem;
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
     color: #aaa;
 }
 .counter strong { color: #e5e5e5; }
 
 /* Hero */
 .hero {
-    padding: 3rem 1rem;
+    padding: 1.5rem 1rem;
     border-radius: 1rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
+    cursor: pointer;
 }
 
 .hero h1 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
     color: #ccc;
 }
 
@@ -79,19 +80,19 @@ main {
 
 /* Answer text */
 .answer {
-    font-size: 8rem;
+    font-size: 5rem;
     font-weight: 900;
     line-height: 1;
-    margin: 1rem 0;
+    margin: 0.5rem 0;
 }
 
 .answer-yes { color: #22c55e; }
 .answer-no { color: #ef4444; }
 
 .subtitle {
-    font-size: 1.1rem;
+    font-size: 0.95rem;
     color: #aaa;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.5rem;
 }
 
 /* Siren */

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -143,26 +143,30 @@ main {
 .calendar-container {
     background: #1a1a1a;
     border-radius: 1rem;
-    padding: 2rem;
+    padding: 1.5rem;
     margin-bottom: 2rem;
+    max-width: 420px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .calendar-container h2 {
-    font-size: 1.2rem;
+    font-size: 1rem;
     color: #ccc;
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
+    text-align: center;
 }
 
 .calendar-header {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    gap: 0.4rem;
-    margin-bottom: 0.4rem;
+    gap: 0.3rem;
+    margin-bottom: 0.3rem;
 }
 
 .calendar-header span {
     text-align: center;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
     color: #666;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -171,8 +175,8 @@ main {
 .calendar-week {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    gap: 0.4rem;
-    margin-bottom: 0.4rem;
+    gap: 0.3rem;
+    margin-bottom: 0.3rem;
 }
 
 .calendar-day {
@@ -217,12 +221,12 @@ main {
 }
 
 .day-num {
-    font-size: 0.65rem;
+    font-size: 0.55rem;
     color: #888;
 }
 
 .day-icon {
-    font-size: 1.1rem;
+    font-size: 0.9rem;
     line-height: 1;
 }
 
@@ -231,10 +235,48 @@ main {
 .day-amber .day-icon { color: #f59e0b; }
 
 .day-count {
-    font-size: 0.65rem;
+    font-size: 0.55rem;
     font-weight: 700;
     color: #22c55e;
     line-height: 1;
+}
+
+/* Day status banners */
+.day-status {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: 0.75rem;
+    margin: 1.5rem 0;
+}
+
+.day-status p {
+    color: #ccc;
+    font-size: 1rem;
+}
+
+.day-status-icon {
+    font-size: 2rem;
+    flex-shrink: 0;
+}
+
+.day-status-red {
+    background: #2a0a0a;
+    border: 1px solid #ef4444;
+}
+
+.day-status-red .day-status-icon {
+    color: #ef4444;
+}
+
+.day-status-amber {
+    background: #1a1500;
+    border: 1px solid #f59e0b;
+}
+
+.day-status-amber .day-status-icon {
+    color: #f59e0b;
 }
 
 /* Back link */

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -139,7 +139,7 @@ main {
     color: #fff;
 }
 
-/* Calendar grid */
+/* Calendar */
 .calendar-container {
     background: #1a1a1a;
     border-radius: 1rem;
@@ -153,10 +153,26 @@ main {
     margin-bottom: 1rem;
 }
 
-.calendar-grid {
+.calendar-header {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
-    gap: 0.5rem;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.4rem;
+    margin-bottom: 0.4rem;
+}
+
+.calendar-header span {
+    text-align: center;
+    font-size: 0.7rem;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.calendar-week {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 0.4rem;
+    margin-bottom: 0.4rem;
 }
 
 .calendar-day {
@@ -164,7 +180,7 @@ main {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.15rem;
+    gap: 0.1rem;
     aspect-ratio: 1;
     border-radius: 0.5rem;
     text-decoration: none;
@@ -172,9 +188,17 @@ main {
     transition: transform 0.1s, box-shadow 0.1s;
 }
 
-.calendar-day:hover {
+.calendar-day:hover:not(.day-empty) {
     transform: scale(1.08);
     box-shadow: 0 0 12px rgba(255, 255, 255, 0.1);
+}
+
+.day-empty {
+    background: transparent;
+}
+
+.day-faded {
+    opacity: 0.4;
 }
 
 .day-green {
@@ -189,16 +213,17 @@ main {
 
 .day-amber {
     background: #1a1500;
-    border: 1px solid #555;
+    border: 1px solid #444;
 }
 
-.day-date {
-    font-size: 0.7rem;
+.day-num {
+    font-size: 0.65rem;
     color: #888;
 }
 
 .day-icon {
-    font-size: 1.2rem;
+    font-size: 1.1rem;
+    line-height: 1;
 }
 
 .day-green .day-icon { color: #22c55e; }
@@ -206,9 +231,10 @@ main {
 .day-amber .day-icon { color: #f59e0b; }
 
 .day-count {
-    font-size: 0.75rem;
+    font-size: 0.65rem;
     font-weight: 700;
     color: #22c55e;
+    line-height: 1;
 }
 
 /* Back link */

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -139,18 +139,76 @@ main {
     color: #fff;
 }
 
-/* Chart */
-.chart-container {
+/* Calendar grid */
+.calendar-container {
     background: #1a1a1a;
     border-radius: 1rem;
     padding: 2rem;
     margin-bottom: 2rem;
 }
 
-.chart-container h2 {
+.calendar-container h2 {
     font-size: 1.2rem;
     color: #ccc;
     margin-bottom: 1rem;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+    gap: 0.5rem;
+}
+
+.calendar-day {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15rem;
+    aspect-ratio: 1;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.calendar-day:hover {
+    transform: scale(1.08);
+    box-shadow: 0 0 12px rgba(255, 255, 255, 0.1);
+}
+
+.day-green {
+    background: #0a2a0a;
+    border: 1px solid #22c55e;
+}
+
+.day-red {
+    background: #2a0a0a;
+    border: 1px solid #ef4444;
+}
+
+.day-amber {
+    background: #1a1500;
+    border: 1px solid #555;
+}
+
+.day-date {
+    font-size: 0.7rem;
+    color: #888;
+}
+
+.day-icon {
+    font-size: 1.2rem;
+}
+
+.day-green .day-icon { color: #22c55e; }
+.day-red .day-icon { color: #ef4444; }
+.day-amber .day-icon { color: #f59e0b; }
+
+.day-count {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #22c55e;
 }
 
 /* Back link */

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,13 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=2">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <link rel="stylesheet" href="/static/style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=2"></script>
+    <script src="/static/app.js?v=3"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=4">
+    <link rel="stylesheet" href="/static/style.css?v=5">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=4"></script>
+    <script src="/static/app.js?v=5"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=5">
+    <link rel="stylesheet" href="/static/style.css?v=6">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=5"></script>
+    <script src="/static/app.js?v=6"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=3">
+    <link rel="stylesheet" href="/static/style.css?v=4">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=3"></script>
+    <script src="/static/app.js?v=4"></script>
 </body>
 </html>

--- a/src/web/templates/day_detail.html
+++ b/src/web/templates/day_detail.html
@@ -3,6 +3,18 @@
 <a href="/" class="back-link">&larr; Back to Home</a>
 
 <h1>{{ target_date.strftime('%B %d, %Y') }}</h1>
+
+{% if not scraped %}
+<div class="day-status day-status-amber">
+    <span class="day-status-icon">?</span>
+    <p>No scraping was performed on this date. There is no data available.</p>
+</div>
+{% elif total == 0 %}
+<div class="day-status day-status-red">
+    <span class="day-status-icon">&#9888;</span>
+    <p>Scraping ran but no software engineering postings were found.</p>
+</div>
+{% else %}
 <p class="subtitle">{{ total }} software engineering posting{{ 's' if total != 1 else '' }} found</p>
 
 {% for company, jobs in by_company.items() %}
@@ -34,9 +46,5 @@
     </div>
 </div>
 {% endfor %}
-
-{% if total == 0 %}
-<p class="warning-icon">&#9888;</p>
-<p>No software engineering postings found on this date.</p>
 {% endif %}
 {% endblock %}

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -38,23 +38,29 @@
 
 <section class="calendar-container">
     <h2>Last 30 Days</h2>
-    <div class="calendar-grid">
-        {% for day in daily_counts %}
-        <a href="/day/{{ day.date }}" class="calendar-day {% if day.count > 0 %}day-green{% elif day.scraped %}day-red{% else %}day-amber{% endif %}">
-            <span class="day-date">{{ day.date[5:] }}</span>
-            <span class="day-icon">
-                {%- if day.count > 0 -%}
-                    &#10003;
-                {%- elif day.scraped -%}
-                    &#9888;
-                {%- else -%}
-                    &#63;
-                {%- endif -%}
-            </span>
-            {% if day.count > 0 %}
-            <span class="day-count">{{ day.count }}</span>
-            {% endif %}
-        </a>
+    <div class="calendar">
+        <div class="calendar-header">
+            <span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span><span>Sun</span>
+        </div>
+        {% for week in calendar_weeks %}
+        <div class="calendar-week">
+            {% for day in week %}
+                {% if day %}
+                <a href="/day/{{ day.date }}"
+                   class="calendar-day {% if day.count > 0 %}day-green{% elif day.scraped %}day-red{% else %}day-amber{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
+                    <span class="day-num">{{ day.day_num }}</span>
+                    <span class="day-icon">
+                        {%- if day.count > 0 -%}&#10003;{%- elif day.scraped -%}&#9888;{%- else -%}?{%- endif -%}
+                    </span>
+                    {% if day.count > 0 %}
+                    <span class="day-count">{{ day.count }}</span>
+                    {% endif %}
+                </a>
+                {% else %}
+                <div class="calendar-day day-empty"></div>
+                {% endif %}
+            {% endfor %}
+        </div>
         {% endfor %}
     </div>
 </section>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -9,18 +9,16 @@
     </p>
 </section>
 
-<section class="hero hero-{{ state }}">
+<section class="hero hero-{{ state }}" {% if state == "yes" %}onclick="playCelebrate()"{% elif state == "no" %}onclick="playAlarm()"{% endif %}>
     <h1>Is Big AI still hiring Software Engineers?</h1>
     {% if state == "yes" %}
         <p class="answer answer-yes">YES</p>
         <p class="subtitle">{{ count }} software engineering positions found</p>
-        <button class="celebrate-btn" onclick="playCelebrate()">Click to celebrate</button>
     {% elif state == "no" %}
         <div class="siren"></div>
         <p class="answer answer-no">NO</p>
         <p class="warning-icon">&#9888;</p>
         <p class="subtitle">No software engineering positions found</p>
-        <button class="alarm-btn" onclick="playAlarm()">Click to panic</button>
     {% else %}
         <p class="answer answer-unsure">&#8230;</p>
         <p class="subtitle unsure-subtitle">Unsure yet, still checking</p>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -36,16 +36,30 @@
     {% endif %}
 </section>
 
-<section class="chart-container">
-    <h2>Daily Software Engineering Postings (Last 30 Days)</h2>
-    <canvas id="postsChart"></canvas>
+<section class="calendar-container">
+    <h2>Last 30 Days</h2>
+    <div class="calendar-grid">
+        {% for day in daily_counts %}
+        <a href="/day/{{ day.date }}" class="calendar-day {% if day.count > 0 %}day-green{% elif day.scraped %}day-red{% else %}day-amber{% endif %}">
+            <span class="day-date">{{ day.date[5:] }}</span>
+            <span class="day-icon">
+                {%- if day.count > 0 -%}
+                    &#10003;
+                {%- elif day.scraped -%}
+                    &#9888;
+                {%- else -%}
+                    &#63;
+                {%- endif -%}
+            </span>
+            {% if day.count > 0 %}
+            <span class="day-count">{{ day.count }}</span>
+            {% endif %}
+        </a>
+        {% endfor %}
+    </div>
 </section>
 
 {% if state == "unsure" %}
 <script>setTimeout(() => location.reload(), 10000);</script>
 {% endif %}
-
-<script>
-    const dailyCounts = {{ daily_counts | tojson }};
-</script>
 {% endblock %}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -25,7 +25,7 @@ async def _seed_postings(db_session, target_date: date, count: int = 3):
         id=uuid.uuid4(),
         company="anthropic",
         status="success",
-        started_at=datetime.now(UTC),
+        started_at=datetime.combine(target_date, datetime.min.time(), tzinfo=UTC),
         attempt_number=1,
     )
     db_session.add(run)
@@ -102,11 +102,30 @@ async def test_day_detail_page(client, db_session):
     assert "3 posting" in response.text
 
 
-async def test_day_detail_empty(client):
+async def test_day_detail_no_scrape(client):
+    """Day with no scrape data should show amber 'no scraping' message."""
     target = date(2020, 1, 1)
     response = await client.get(f"/day/{target.isoformat()}")
     assert response.status_code == 200
-    assert "0 software engineering posting" in response.text
+    assert "No scraping was performed" in response.text
+
+
+async def test_day_detail_scraped_no_postings(client, db_session):
+    """Day with scrapes but 0 SWE postings should show red warning."""
+    target = date.today() - timedelta(days=2)
+    run = ScrapeRun(
+        id=uuid.uuid4(),
+        company="anthropic",
+        status="success",
+        started_at=datetime.combine(target, datetime.min.time(), tzinfo=UTC),
+        attempt_number=1,
+        postings_found=0,
+    )
+    db_session.add(run)
+    await db_session.commit()
+    response = await client.get(f"/day/{target.isoformat()}")
+    assert response.status_code == 200
+    assert "no software engineering postings were found" in response.text
 
 
 async def test_scrape_status_page(client, db_session):

--- a/tests/integration/test_queries.py
+++ b/tests/integration/test_queries.py
@@ -247,6 +247,8 @@ async def test_get_daily_counts(db_session):
     assert counts[4]["count"] == 1
     # Dates should be ascending
     assert counts[0]["date"] < counts[4]["date"]
+    # Each entry should have a 'scraped' key
+    assert all("scraped" in c for c in counts)
 
 
 async def test_get_recent_scrape_runs(db_session):


### PR DESCRIPTION
## Summary
- Replace Chart.js bar chart with a 30-day calendar grid
- Each day is a clickable square showing status:
  - **Green + tick + count**: SWE postings found
  - **Red + warning**: scraped but 0 SWE postings
  - **Amber + question mark**: no scrape data for that day
- Remove Chart.js CDN dependency
- Update `get_daily_counts` query to include per-day scrape status

## Test plan
- [x] `make test` — 40 tests pass
- [ ] Visual check in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)