### PR TITLE
Call venv binaries directly at runtime (skip uv overhead)

### DIFF
--- a/Containerfile.scraper
+++ b/Containerfile.scraper
@@ -4,4 +4,4 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 COPY pyproject.toml uv.lock ./
 COPY src/ src/
 RUN uv sync --no-dev --frozen
-CMD ["uv", "run", "python", "-m", "src.scrapers.scheduler"]
+CMD [".venv/bin/python", "-m", "src.scrapers.scheduler"]

--- a/scripts/web-entrypoint.sh
+++ b/scripts/web-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Running database migrations..."
-uv run alembic upgrade head
+.venv/bin/alembic upgrade head
 
 echo "Starting web server..."
-exec uv run uvicorn src.web.app:create_app --factory --host 0.0.0.0 --port 8000
+exec .venv/bin/uvicorn src.web.app:create_app --factory --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
Previously container CMDs used \`uv run\` which triggers dep resolution/sync on every start. Switched to calling \`.venv/bin/*\` directly for faster startup and a smaller runtime surface.

- \`Containerfile.scraper\`: \`CMD [\".venv/bin/python\", \"-m\", \"src.scrapers.scheduler\"]\`
- \`scripts/web-entrypoint.sh\`: uses \`.venv/bin/alembic\` and \`.venv/bin/uvicorn\`
- Build step still uses uv for dependency installation

## Test plan
- [x] \`make test\` — 41 pass
- [ ] Rebuild and verify containers still start (Pi and dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)