### PR TITLE
Home page 'classifying' state while postings are being processed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ OLLAMA_MODEL=gemma4:e2b
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_TIMEOUT_SECONDS=60
 CLASSIFY_CONCURRENCY=4
+CLASSIFY_ENABLED=true
 ANTHROPIC_CAREERS_URL=https://www.anthropic.com/careers
 OPENAI_CAREERS_URL=https://openai.com/careers
 DEEPMIND_CAREERS_URL=https://deepmind.google/about/careers/

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     ollama_host: str = "http://localhost:11434"
     ollama_timeout_seconds: float = 60.0
     classify_concurrency: int = 4
+    classify_enabled: bool = True
     anthropic_careers_url: str = "https://www.anthropic.com/careers"
     openai_careers_url: str = "https://openai.com/careers"
     deepmind_careers_url: str = "https://deepmind.google/about/careers/"

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -62,6 +62,7 @@ async def get_daily_counts(
       - date: the date
       - count: number of SWE postings active on that day
       - scraped: whether at least one successful scrape ran that day
+      - classifying: postings active on this day have classified_at IS NULL
     """
     today = date.today()
     results = []
@@ -79,6 +80,16 @@ async def get_daily_counts(
         )
         count = count_result.scalar()
 
+        # Count unclassified postings active on this day
+        unclassified_result = await session.execute(
+            select(func.count(JobPosting.id)).where(
+                JobPosting.first_seen_date <= d,
+                JobPosting.last_seen_date >= d,
+                JobPosting.classified_at.is_(None),
+            )
+        )
+        classifying = (unclassified_result.scalar() or 0) > 0
+
         # Check if any successful scrape ran on this day
         day_start = datetime.combine(d, datetime.min.time(), tzinfo=UTC)
         day_end = datetime.combine(d + timedelta(days=1), datetime.min.time(), tzinfo=UTC)
@@ -91,9 +102,21 @@ async def get_daily_counts(
         )
         scraped = (scrape_result.scalar() or 0) > 0
 
-        results.append({"date": d, "count": count, "scraped": scraped})
+        results.append({"date": d, "count": count, "scraped": scraped, "classifying": classifying})
 
     return results
+
+
+async def get_unclassified_count_for_date(session: AsyncSession, target_date: date) -> int:
+    """Count postings active on target_date that haven't been classified yet."""
+    result = await session.execute(
+        select(func.count(JobPosting.id)).where(
+            JobPosting.first_seen_date <= target_date,
+            JobPosting.last_seen_date >= target_date,
+            JobPosting.classified_at.is_(None),
+        )
+    )
+    return result.scalar() or 0
 
 
 async def get_postings_for_date(

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -199,6 +199,18 @@ async def get_todays_scrape_summary(session: AsyncSession) -> dict:
         if count > 0:
             break
 
+    # Classification stats for postings active today
+    active_today_stmt = select(func.count(JobPosting.id)).where(
+        JobPosting.first_seen_date <= today,
+        JobPosting.last_seen_date >= today,
+    )
+    active_today_result = await session.execute(active_today_stmt)
+    active_today_total = active_today_result.scalar() or 0
+
+    unclassified_today_result = await session.execute(active_today_stmt.where(JobPosting.classified_at.is_(None)))
+    unclassified_today = unclassified_today_result.scalar() or 0
+    classified_today = active_today_total - unclassified_today
+
     return {
         "succeeded": succeeded,
         "running": running,
@@ -206,4 +218,7 @@ async def get_todays_scrape_summary(session: AsyncSession) -> dict:
         "total_companies": len(companies),
         "has_postings": count > 0,
         "posting_count": count,
+        "active_today_total": active_today_total,
+        "classified_today": classified_today,
+        "unclassified_today": unclassified_today,
     }

--- a/src/scrapers/scheduler.py
+++ b/src/scrapers/scheduler.py
@@ -105,7 +105,12 @@ async def classify_postings(
         force: If True, reclassify all postings. If False, only unclassified ones.
 
     Returns number of postings classified.
+    Returns 0 without any work if settings.classify_enabled is False.
     """
+    if not settings.classify_enabled:
+        logger.info("Classification disabled (CLASSIFY_ENABLED=false); skipping.")
+        return 0
+
     factory = session_factory or get_session_factory()
     now = datetime.now(UTC)
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -73,12 +73,15 @@ def create_app(db_session_override=None) -> FastAPI:
             calendar_weeks.append(week)
 
         # Determine display state:
-        # "yes"     - at least one scraper finished and found SWE postings
-        # "no"      - at least 2/3 scrapers succeeded and all returned 0
-        # "unsure"  - scrapers still running or not enough data
+        # "yes"         - at least one scraper finished and found SWE postings
+        # "classifying" - postings fetched but some not yet classified
+        # "no"          - all of today's postings classified, none are SWE
+        # "unsure"      - scrapers still running or haven't run today
         if summary["has_postings"]:
             state = "yes"
-        elif summary["succeeded"] >= 2 and not summary["has_postings"]:
+        elif summary["unclassified_today"] > 0:
+            state = "classifying"
+        elif summary["succeeded"] >= 2 and summary["active_today_total"] > 0:
             state = "no"
         else:
             state = "unsure"

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -43,7 +43,12 @@ def create_app(db_session_override=None) -> FastAPI:
         raw_counts = await get_daily_counts(session)
         # Build a lookup by date string
         day_data = {
-            d["date"].isoformat(): {"date": d["date"].isoformat(), "count": d["count"], "scraped": d["scraped"]}
+            d["date"].isoformat(): {
+                "date": d["date"].isoformat(),
+                "count": d["count"],
+                "scraped": d["scraped"],
+                "classifying": d["classifying"],
+            }
             for d in raw_counts
         }
 
@@ -60,7 +65,7 @@ def create_app(db_session_override=None) -> FastAPI:
         d = start
         while d <= today:
             iso = d.isoformat()
-            entry = day_data.get(iso, {"date": iso, "count": 0, "scraped": False})
+            entry = day_data.get(iso, {"date": iso, "count": 0, "scraped": False, "classifying": False})
             entry["in_current_month"] = d.month == current_month
             entry["day_num"] = d.day
             entry["weekday"] = d.strftime("%a")
@@ -105,11 +110,12 @@ def create_app(db_session_override=None) -> FastAPI:
 
     @app.get("/day/{target_date}")
     async def day_detail(request: Request, target_date: str, session: AsyncSession = Depends(get_session)):
-        from src.db.queries import get_scrape_runs_for_date
+        from src.db.queries import get_scrape_runs_for_date, get_unclassified_count_for_date
 
         parsed_date = date.fromisoformat(target_date)
         postings = await get_postings_for_date(session, parsed_date)
         scrape_runs = await get_scrape_runs_for_date(session, parsed_date)
+        unclassified = await get_unclassified_count_for_date(session, parsed_date)
         by_company: dict[str, list] = {}
         for p in postings:
             by_company.setdefault(p.company, []).append(p)
@@ -125,6 +131,7 @@ def create_app(db_session_override=None) -> FastAPI:
                 "total": len(postings),
                 "scraped": scraped,
                 "scrape_runs": scrape_runs,
+                "unclassified": unclassified,
             },
         )
 

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -221,6 +221,11 @@ main {
     border: 1px solid #444;
 }
 
+.day-classifying {
+    background: #1a1500;
+    border: 1px solid #f59e0b;
+}
+
 .day-num {
     font-size: 0.55rem;
     color: #888;
@@ -234,6 +239,29 @@ main {
 .day-green .day-icon { color: #22c55e; }
 .day-red .day-icon { color: #ef4444; }
 .day-amber .day-icon { color: #f59e0b; }
+.day-classifying .day-icon { color: #f59e0b; }
+
+/* Loading spinner */
+.spinner {
+    display: inline-block;
+    width: 0.8rem;
+    height: 0.8rem;
+    border: 2px solid rgba(245, 158, 11, 0.25);
+    border-top-color: #f59e0b;
+    border-radius: 50%;
+    animation: spinner-rotate 0.8s linear infinite;
+    vertical-align: middle;
+}
+
+.spinner-lg {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-width: 3px;
+}
+
+@keyframes spinner-rotate {
+    to { transform: rotate(360deg); }
+}
 
 .day-count {
     font-size: 0.55rem;

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -396,7 +396,7 @@ main {
 }
 
 /* Unsure state */
-.hero-unsure { animation: pulse-amber 3s ease-in-out infinite; }
+.hero-unsure, .hero-classifying { animation: pulse-amber 3s ease-in-out infinite; }
 @keyframes pulse-amber {
     0%, 100% { background: #111; }
     50% { background: #1a1500; }

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=8">
+    <link rel="stylesheet" href="/static/style.css?v=9">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=8"></script>
+    <script src="/static/app.js?v=9"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=7">
+    <link rel="stylesheet" href="/static/style.css?v=8">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=7"></script>
+    <script src="/static/app.js?v=8"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=9">
+    <link rel="stylesheet" href="/static/style.css?v=10">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=9"></script>
+    <script src="/static/app.js?v=10"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Are They Still Hiring Software Engineers?</title>
-    <link rel="stylesheet" href="/static/style.css?v=6">
+    <link rel="stylesheet" href="/static/style.css?v=7">
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1"></script>
 </head>
 <body>
     <nav><a href="/scrapes" class="scrapes-btn" title="Scrape Status">&#9881;</a></nav>
     <main>{% block content %}{% endblock %}</main>
-    <script src="/static/app.js?v=6"></script>
+    <script src="/static/app.js?v=7"></script>
 </body>
 </html>

--- a/src/web/templates/day_detail.html
+++ b/src/web/templates/day_detail.html
@@ -9,6 +9,11 @@
     <span class="day-status-icon">?</span>
     <p>No scraping was performed on this date. There is no data available.</p>
 </div>
+{% elif total == 0 and unclassified > 0 %}
+<div class="day-status day-status-amber">
+    <span class="day-status-icon"><span class="spinner spinner-lg"></span></span>
+    <p>Still checking &mdash; {{ unclassified }} posting{{ 's' if unclassified != 1 else '' }} pending classification.</p>
+</div>
 {% elif total == 0 %}
 <div class="day-status day-status-red">
     <span class="day-status-icon">&#9888;</span>
@@ -46,5 +51,9 @@
     </div>
 </div>
 {% endfor %}
+{% endif %}
+
+{% if total == 0 and unclassified > 0 %}
+<script>setTimeout(() => location.reload(), 10000);</script>
 {% endif %}
 {% endblock %}

--- a/src/web/templates/day_detail.html
+++ b/src/web/templates/day_detail.html
@@ -53,7 +53,7 @@
 {% endfor %}
 {% endif %}
 
-{% if total == 0 and unclassified > 0 %}
+{% if scraped and total == 0 and unclassified > 0 %}
 <script>setTimeout(() => location.reload(), 10000);</script>
 {% endif %}
 {% endblock %}

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -52,13 +52,13 @@
             {% for day in week %}
                 {% if day %}
                 <a href="/day/{{ day.date }}"
-                   class="calendar-day {% if day.count > 0 %}day-green{% elif day.classifying %}day-classifying{% elif day.scraped %}day-red{% else %}day-amber{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
+                   class="calendar-day {% if day.count > 0 %}day-green{% elif not day.scraped %}day-amber{% elif day.classifying %}day-classifying{% else %}day-red{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
                     <span class="day-num">{{ day.day_num }}</span>
                     <span class="day-icon">
                         {%- if day.count > 0 -%}&#10003;
+                        {%- elif not day.scraped -%}?
                         {%- elif day.classifying -%}<span class="spinner"></span>
-                        {%- elif day.scraped -%}&#9888;
-                        {%- else -%}?{%- endif -%}
+                        {%- else -%}&#9888;{%- endif -%}
                     </span>
                     {% if day.count > 0 %}
                     <span class="day-count">{{ day.count }}</span>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -52,15 +52,15 @@
             {% for day in week %}
                 {% if day %}
                 <a href="/day/{{ day.date }}"
-                   class="calendar-day {% if day.count > 0 %}day-green{% elif not day.scraped %}day-amber{% elif day.classifying %}day-classifying{% else %}day-red{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
+                   class="calendar-day {% if not day.scraped %}day-amber{% elif day.classifying %}day-classifying{% elif day.count > 0 %}day-green{% else %}day-red{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
                     <span class="day-num">{{ day.day_num }}</span>
                     <span class="day-icon">
-                        {%- if day.count > 0 -%}&#10003;
-                        {%- elif not day.scraped -%}?
+                        {%- if not day.scraped -%}?
                         {%- elif day.classifying -%}<span class="spinner"></span>
+                        {%- elif day.count > 0 -%}&#10003;
                         {%- else -%}&#9888;{%- endif -%}
                     </span>
-                    {% if day.count > 0 %}
+                    {% if day.scraped and day.count > 0 and not day.classifying %}
                     <span class="day-count">{{ day.count }}</span>
                     {% endif %}
                 </a>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -52,10 +52,13 @@
             {% for day in week %}
                 {% if day %}
                 <a href="/day/{{ day.date }}"
-                   class="calendar-day {% if day.count > 0 %}day-green{% elif day.scraped %}day-red{% else %}day-amber{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
+                   class="calendar-day {% if day.count > 0 %}day-green{% elif day.classifying %}day-classifying{% elif day.scraped %}day-red{% else %}day-amber{% endif %} {% if not day.in_current_month %}day-faded{% endif %}">
                     <span class="day-num">{{ day.day_num }}</span>
                     <span class="day-icon">
-                        {%- if day.count > 0 -%}&#10003;{%- elif day.scraped -%}&#9888;{%- else -%}?{%- endif -%}
+                        {%- if day.count > 0 -%}&#10003;
+                        {%- elif day.classifying -%}<span class="spinner"></span>
+                        {%- elif day.scraped -%}&#9888;
+                        {%- else -%}?{%- endif -%}
                     </span>
                     {% if day.count > 0 %}
                     <span class="day-count">{{ day.count }}</span>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -19,6 +19,13 @@
         <p class="answer answer-no">NO</p>
         <p class="warning-icon">&#9888;</p>
         <p class="subtitle">No software engineering positions found</p>
+    {% elif state == "classifying" %}
+        <p class="answer answer-unsure">&#8230;</p>
+        <p class="subtitle unsure-subtitle">Still checking &mdash; classifying today's postings</p>
+        <div class="scrape-progress-summary">
+            <span>{{ scrape_summary.classified_today }}/{{ scrape_summary.active_today_total }} classified</span>
+            <span class="status-running">&bull; {{ scrape_summary.unclassified_today }} remaining</span>
+        </div>
     {% else %}
         <p class="answer answer-unsure">&#8230;</p>
         <p class="subtitle unsure-subtitle">Unsure yet, still checking</p>
@@ -63,7 +70,7 @@
     </div>
 </section>
 
-{% if state == "unsure" %}
+{% if state == "unsure" or state == "classifying" %}
 <script>setTimeout(() => location.reload(), 10000);</script>
 {% endif %}
 {% endblock %}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -72,7 +72,8 @@ async def test_home_page_unsure_state(client):
 
 
 async def test_home_page_no_state(client, db_session):
-    """With 2+ successful scrapers returning 0 postings, state should be 'NO'."""
+    """With postings fetched today, all classified, none SWE -> 'NO'."""
+    today = date.today()
     for company in ["anthropic", "openai"]:
         run = ScrapeRun(
             id=uuid.uuid4(),
@@ -80,14 +81,79 @@ async def test_home_page_no_state(client, db_session):
             status="success",
             started_at=datetime.now(UTC),
             attempt_number=1,
-            postings_found=0,
+            postings_found=1,
         )
         db_session.add(run)
+        await db_session.flush()
+        db_session.add(
+            JobPosting(
+                id=uuid.uuid4(),
+                scrape_run_id=run.id,
+                company=company,
+                title="Product Manager",
+                location="SF",
+                url=f"https://{company}.com/pm",
+                first_seen_date=today,
+                last_seen_date=today,
+                is_software_engineering=False,
+                classified_at=datetime.now(UTC),
+            )
+        )
     await db_session.commit()
     response = await client.get("/")
     assert response.status_code == 200
     assert "NO" in response.text
     assert "hero-no" in response.text
+
+
+async def test_home_page_classifying_state(client, db_session):
+    """With postings fetched today but some unclassified -> 'classifying'."""
+    today = date.today()
+    run = ScrapeRun(
+        id=uuid.uuid4(),
+        company="anthropic",
+        status="success",
+        started_at=datetime.now(UTC),
+        attempt_number=1,
+        postings_found=2,
+    )
+    db_session.add(run)
+    await db_session.flush()
+    # One classified, one not
+    db_session.add(
+        JobPosting(
+            id=uuid.uuid4(),
+            scrape_run_id=run.id,
+            company="anthropic",
+            title="Marketing",
+            location="SF",
+            url="https://anthropic.com/mkt",
+            first_seen_date=today,
+            last_seen_date=today,
+            is_software_engineering=False,
+            classified_at=datetime.now(UTC),
+        )
+    )
+    db_session.add(
+        JobPosting(
+            id=uuid.uuid4(),
+            scrape_run_id=run.id,
+            company="anthropic",
+            title="Not yet classified",
+            location="SF",
+            url="https://anthropic.com/pending",
+            first_seen_date=today,
+            last_seen_date=today,
+            is_software_engineering=False,
+            classified_at=None,
+        )
+    )
+    await db_session.commit()
+    response = await client.get("/")
+    assert response.status_code == 200
+    assert "hero-classifying" in response.text
+    assert "classifying" in response.text.lower()
+    assert "1/2 classified" in response.text
 
 
 async def test_day_detail_page(client, db_session):

--- a/tests/integration/test_queries.py
+++ b/tests/integration/test_queries.py
@@ -247,8 +247,9 @@ async def test_get_daily_counts(db_session):
     assert counts[4]["count"] == 1
     # Dates should be ascending
     assert counts[0]["date"] < counts[4]["date"]
-    # Each entry should have a 'scraped' key
+    # Each entry should have 'scraped' and 'classifying' keys
     assert all("scraped" in c for c in counts)
+    assert all("classifying" in c for c in counts)
 
 
 async def test_get_recent_scrape_runs(db_session):

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -151,3 +151,27 @@ async def test_reclassify_postings(session_factory):
     swe = next(p for p in postings if p.title == "Software Engineer")
     assert swe.is_software_engineering is False
     assert pm.is_software_engineering is True
+
+
+@pytest.mark.asyncio
+async def test_classify_postings_disabled(session_factory):
+    """When CLASSIFY_ENABLED is false, classify_postings is a no-op."""
+    with patch.dict(SCRAPERS, {"fake": FakeScraper}):
+        await fetch_and_save("fake", session_factory)
+
+    mock_classify = AsyncMock()
+    with (
+        patch("src.scrapers.scheduler.settings") as mock_settings,
+        patch("src.scrapers.scheduler.classify_titles", mock_classify),
+    ):
+        mock_settings.classify_enabled = False
+        count = await classify_postings(company="fake", session_factory=session_factory)
+
+    assert count == 0
+    mock_classify.assert_not_called()
+
+    # Postings remain unclassified
+    async with session_factory() as session:
+        res = await session.execute(select(JobPosting).where(JobPosting.company == "fake"))
+        postings = list(res.scalars().all())
+    assert all(p.classified_at is None for p in postings)


### PR DESCRIPTION
## Summary
Previously the home page could flip to a red 'NO' the moment scrapes finished but before classification completed — misleading. The Pi takes ~30 min to classify ~1000 postings; during that window we don't actually know whether any are SWE.

New state order:
1. **YES** — at least one classified SWE posting found
2. **classifying** — any postings fetched today have \`classified_at IS NULL\`
3. **NO** — all of today's postings classified, none are SWE
4. **Unsure** — no scrape data for today

The classifying state shows \`X/Y classified\` plus \`N remaining\`, auto-refreshes every 10s (same as Unsure).

## Changes
- \`get_todays_scrape_summary\` returns \`active_today_total\`, \`classified_today\`, \`unclassified_today\`
- \`home\` route picks the new state
- Template adds the \`classifying\` branch
- CSS shares the \`pulse-amber\` animation
- Auto-refresh script fires for both \`unsure\` and \`classifying\`
- Tests: updated \`test_home_page_no_state\` (now must seed actual postings), added \`test_home_page_classifying_state\`

## Test plan
- [x] \`make test\` — 42 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)