### PR TITLE
Add CLASSIFY_ENABLED flag to disable classification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ OLLAMA_MODEL=gemma4:e2b
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_TIMEOUT_SECONDS=60
 CLASSIFY_CONCURRENCY=4
+CLASSIFY_ENABLED=true
 ANTHROPIC_CAREERS_URL=https://www.anthropic.com/careers
 OPENAI_CAREERS_URL=https://openai.com/careers
 DEEPMIND_CAREERS_URL=https://deepmind.google/about/careers/

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     ollama_host: str = "http://localhost:11434"
     ollama_timeout_seconds: float = 60.0
     classify_concurrency: int = 4
+    classify_enabled: bool = True
     anthropic_careers_url: str = "https://www.anthropic.com/careers"
     openai_careers_url: str = "https://openai.com/careers"
     deepmind_careers_url: str = "https://deepmind.google/about/careers/"

--- a/src/scrapers/scheduler.py
+++ b/src/scrapers/scheduler.py
@@ -105,7 +105,12 @@ async def classify_postings(
         force: If True, reclassify all postings. If False, only unclassified ones.
 
     Returns number of postings classified.
+    Returns 0 without any work if settings.classify_enabled is False.
     """
+    if not settings.classify_enabled:
+        logger.info("Classification disabled (CLASSIFY_ENABLED=false); skipping.")
+        return 0
+
     factory = session_factory or get_session_factory()
     now = datetime.now(UTC)
 

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -151,3 +151,27 @@ async def test_reclassify_postings(session_factory):
     swe = next(p for p in postings if p.title == "Software Engineer")
     assert swe.is_software_engineering is False
     assert pm.is_software_engineering is True
+
+
+@pytest.mark.asyncio
+async def test_classify_postings_disabled(session_factory):
+    """When CLASSIFY_ENABLED is false, classify_postings is a no-op."""
+    with patch.dict(SCRAPERS, {"fake": FakeScraper}):
+        await fetch_and_save("fake", session_factory)
+
+    mock_classify = AsyncMock()
+    with (
+        patch("src.scrapers.scheduler.settings") as mock_settings,
+        patch("src.scrapers.scheduler.classify_titles", mock_classify),
+    ):
+        mock_settings.classify_enabled = False
+        count = await classify_postings(company="fake", session_factory=session_factory)
+
+    assert count == 0
+    mock_classify.assert_not_called()
+
+    # Postings remain unclassified
+    async with session_factory() as session:
+        res = await session.execute(select(JobPosting).where(JobPosting.company == "fake"))
+        postings = list(res.scalars().all())
+    assert all(p.classified_at is None for p in postings)


### PR DESCRIPTION
## Summary
Adds a \`CLASSIFY_ENABLED\` env flag (default \`true\`) that short-circuits \`classify_postings()\` into a no-op when set to \`false\`.

Useful for:
- Deployments without Ollama access
- Testing the 'classifying' home page UI state without the background job clearing unclassified postings

Flag behavior:
- \`true\` (default): classify runs as before
- \`false\`: logs \"Classification disabled\" and returns 0; postings remain unclassified

## Test plan
- [x] \`make test\` — 42 pass (added 1 new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)