### PR TITLE
chore: migrate to new Starlette TemplateResponse signature

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -181,7 +181,6 @@ Also re-validate the Playwright E2E suite as part of this work — it hasn't bee
 Smaller items that don't warrant their own top-level entry:
 
 - **Sound effects.** [#23](https://github.com/maciej-makowski/are-they-hiring/issues/23) — Replace empty placeholder MP3s in `src/web/static/sounds/` with actual audio.
-- **Starlette deprecation.** [#25](https://github.com/maciej-makowski/are-they-hiring/issues/25) — Update `TemplateResponse` calls to the new signature.
 - **Classifier prompt refinement.** [#24](https://github.com/maciej-makowski/are-they-hiring/issues/24) — Iterate on the prompt string to fix obvious mis-classifications. Cheap alternative to the full harness (1).
 
 ---

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -95,9 +95,9 @@ def create_app(db_session_override=None) -> FastAPI:
         months = delta.days // 30
         days_r = delta.days % 30
         return templates.TemplateResponse(
+            request,
             "home.html",
             {
-                "request": request,
                 "state": state,
                 "count": summary["posting_count"],
                 "calendar_weeks": calendar_weeks,
@@ -122,9 +122,9 @@ def create_app(db_session_override=None) -> FastAPI:
 
         scraped = len(scrape_runs) > 0
         return templates.TemplateResponse(
+            request,
             "day_detail.html",
             {
-                "request": request,
                 "target_date": parsed_date,
                 "postings": postings,
                 "by_company": by_company,
@@ -138,6 +138,6 @@ def create_app(db_session_override=None) -> FastAPI:
     @app.get("/scrapes")
     async def scrape_status(request: Request, session: AsyncSession = Depends(get_session)):
         runs = await get_recent_scrape_runs(session)
-        return templates.TemplateResponse("scrape_status.html", {"request": request, "runs": runs})
+        return templates.TemplateResponse(request, "scrape_status.html", {"runs": runs})
 
     return app


### PR DESCRIPTION
## Summary
- Update the three `TemplateResponse` call sites in `src/web/app.py` from the deprecated `TemplateResponse(name, {"request": request, ...})` form to the new `TemplateResponse(request, name, {...})` form.
- Pure API-surface migration; no behaviour change.
- Remove the now-done item from `docs/ROADMAP.md`.

Closes #25

## Test plan
- [x] `make test` (43 integration tests pass)
- [x] `make lint` (ruff check + format check pass)
- [x] `pytest -W error::DeprecationWarning` on `tests/integration/test_api.py` passes (previously raised Starlette's deprecation warning; now silent)