### PR TITLE
Add xAI scraper (Greenhouse)

### DIFF
--- a/Implementation.md
+++ b/Implementation.md
@@ -10,8 +10,8 @@
 ## Decision Log
 
 ### 1. Target Companies
-**Decision:** Anthropic, OpenAI, Google DeepMind
-**Rationale:** The three most prominent AI companies making bold claims about AI replacing software engineers. Direct relevance to the project's satirical premise.
+**Decision:** Anthropic, OpenAI, Google DeepMind, xAI (added 2026-04-18)
+**Rationale:** The most prominent AI companies making bold claims about AI replacing software engineers. Direct relevance to the project's satirical premise. Additional labs can be added incrementally via the `SCRAPERS` registry; see roadmap item 6 for the remaining candidates.
 
 ### 2. Frontend Technology
 **Decision:** HTMX + Jinja2 templates served by FastAPI (no separate JS framework)
@@ -23,10 +23,11 @@
 ### 3. Scraping Approach
 **Decision (revised 2026-04-05):** JSON API scraping via httpx (no browser automation)
 **Original decision:** Playwright browser automation for all three companies
-**What changed:** All three companies expose public job board APIs:
+**What changed:** All companies expose public job board APIs:
 - Anthropic: Greenhouse API (`boards-api.greenhouse.io/v1/boards/anthropic/jobs`)
 - OpenAI: Ashby API (`api.ashbyhq.com/posting-api/job-board/openai`)
 - DeepMind: Greenhouse API (`boards-api.greenhouse.io/v1/boards/deepmind/jobs`)
+- xAI: Greenhouse API (`boards-api.greenhouse.io/v1/boards/xai/jobs`)
 **Rationale:** JSON APIs are faster, lighter (no browser/Chromium needed), more reliable, and return structured data. The scraper container went from ~1.3GB (with Chromium) to ~580MB. Playwright is no longer a runtime dependency for scraping.
 
 ### 4. Job Title Classification
@@ -101,11 +102,11 @@
 │  │  APScheduler, runs 3x daily      │             │
 │  │  Pipeline: fetch → classify      │             │
 │  │                                  │             │
-│  │  ┌─────────┐┌────────┐┌───────┐ │             │
-│  │  │Anthropic││OpenAI  ││DeepMind│ │             │
-│  │  │Greenhouse│Ashby   ││Greenhouse│             │
-│  │  │  API    ││  API   ││  API  │ │             │
-│  │  └─────────┘└────────┘└───────┘ │             │
+│  │  ┌─────────┐┌────────┐┌───────┐┌────┐│             │
+│  │  │Anthropic││OpenAI  ││DeepMind││xAI ││             │
+│  │  │Greenhouse│Ashby   ││Greenhouse│Greenhouse│             │
+│  │  │  API    ││  API   ││  API  ││ API││             │
+│  │  └─────────┘└────────┘└───────┘└────┘│             │
 │  └──────────────────────────────────┘             │
 │                                          :8000 ──►│
 └────────────────────────────────────────────────────┘
@@ -121,7 +122,7 @@ All containers communicate over the pod's shared network.
 | Column           | Type      | Notes                                    |
 |------------------|-----------|------------------------------------------|
 | id               | UUID      | Primary key                              |
-| company          | VARCHAR   | anthropic / openai / deepmind            |
+| company          | VARCHAR   | anthropic / openai / deepmind / xai       |
 | status           | VARCHAR   | running / success / failed               |
 | started_at       | TIMESTAMP |                                          |
 | finished_at      | TIMESTAMP | Nullable                                 |
@@ -137,7 +138,7 @@ All containers communicate over the pod's shared network.
 |------------------------|-----------|----------------------------------------|
 | id                     | UUID      | Primary key                            |
 | scrape_run_id          | UUID      | FK to scrape_runs                      |
-| company                | VARCHAR   | anthropic / openai / deepmind          |
+| company                | VARCHAR   | anthropic / openai / deepmind / xai    |
 | title                  | VARCHAR   | Original job title                     |
 | location               | VARCHAR   |                                        |
 | url                    | VARCHAR   | Link to original posting               |
@@ -240,8 +241,9 @@ CLASSIFY_CONCURRENCY=4
 
 # Company APIs (auto-configured, override if needed)
 # Anthropic: boards-api.greenhouse.io/v1/boards/anthropic/jobs
-# OpenAI: api.ashbyhq.com/posting-api/job-board/openai
-# DeepMind: boards-api.greenhouse.io/v1/boards/deepmind/jobs
+# OpenAI:    api.ashbyhq.com/posting-api/job-board/openai
+# DeepMind:  boards-api.greenhouse.io/v1/boards/deepmind/jobs
+# xAI:       boards-api.greenhouse.io/v1/boards/xai/jobs
 ```
 
 ---
@@ -306,6 +308,7 @@ are-they-hiring/
 │   │   ├── anthropic.py               # Greenhouse API parser
 │   │   ├── openai_scraper.py          # Ashby API parser
 │   │   ├── deepmind.py                # Greenhouse API parser
+│   │   ├── xai.py                     # Greenhouse API parser
 │   │   └── scheduler.py               # fetch/classify/reclassify + APScheduler
 │   └── web/
 │       ├── app.py                     # FastAPI app factory + routes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Are They Still Hiring Software Engineers?
 
-A satirical web app that scrapes job postings from Anthropic, OpenAI, and Google DeepMind, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
+A satirical web app that scrapes job postings from Anthropic, OpenAI, Google DeepMind, and xAI, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
 
 > **Contributing?** Read [`AGENTS.md`](AGENTS.md) first — it lays out the repo conventions (branches, commits, tests, docs) both humans and AI agents should follow.
 
@@ -25,7 +25,7 @@ podman-compose -f podman-compose.dev.yml up -d
 open http://localhost:8000
 ```
 
-The web container auto-runs database migrations on startup. The scraper fetches from all 3 company APIs and classifies titles via Ollama immediately, then on the configured schedule.
+The web container auto-runs database migrations on startup. The scraper fetches from all 4 company APIs and classifies titles via Ollama immediately, then on the configured schedule.
 
 ### Port Mappings
 
@@ -271,7 +271,7 @@ Ollama (gemma3:270m, CPU/GPU) → Classification
 ```
 
 - **Web**: FastAPI serves HTMX/Jinja2 pages with Chart.js and confetti
-- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind) and Ashby (OpenAI) JSON APIs
+- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind, xAI) and Ashby (OpenAI) JSON APIs
 - **Classifier**: Parallel Ollama requests to classify job titles as SWE or not
 - **Database**: PostgreSQL with deduplication by (company, URL), first/last seen tracking
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,7 +125,7 @@ Also re-validate the Playwright E2E suite as part of this work — it hasn't bee
 **Goal:** expand the scraper coverage beyond the original three.
 
 **Candidates:**
-- xAI
+- ~~xAI~~ (done — Greenhouse scraper landed 2026-04-18)
 - Meta AI (FAIR)
 - Mistral
 - Cohere

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -179,11 +179,14 @@ async def get_todays_scrape_summary(session: AsyncSession) -> dict:
       - succeeded: number of companies with successful scrapes today
       - running: number of companies with running scrapes
       - failed: number of companies with only failed scrapes today
-      - total_companies: 3 (anthropic, openai, deepmind)
+      - total_companies: number of registered company scrapers
       - has_postings: whether any successful scrape found SWE postings
     """
+    # Import here to avoid a circular import between queries and the scraper registry.
+    from src.scrapers.scheduler import SCRAPERS
+
     today_start = datetime.combine(date.today(), datetime.min.time(), tzinfo=UTC)
-    companies = ["anthropic", "openai", "deepmind"]
+    companies = list(SCRAPERS.keys())
 
     succeeded = 0
     running = 0

--- a/src/scrapers/scheduler.py
+++ b/src/scrapers/scheduler.py
@@ -15,6 +15,7 @@ from src.db.session import get_session_factory
 from src.scrapers.anthropic import AnthropicScraper
 from src.scrapers.deepmind import DeepMindScraper
 from src.scrapers.openai_scraper import OpenAIScraper
+from src.scrapers.xai import XAIScraper
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ SCRAPERS = {
     "anthropic": AnthropicScraper,
     "openai": OpenAIScraper,
     "deepmind": DeepMindScraper,
+    "xai": XAIScraper,
 }
 
 

--- a/src/scrapers/xai.py
+++ b/src/scrapers/xai.py
@@ -1,0 +1,25 @@
+from src.scrapers.base import BaseScraper
+
+
+class XAIScraper(BaseScraper):
+    company = "xai"
+    api_url = "https://boards-api.greenhouse.io/v1/boards/xai/jobs"
+
+    def parse_response(self, data: dict | list) -> list[dict]:
+        jobs = data.get("jobs", []) if isinstance(data, dict) else data
+        postings = []
+        for job in jobs:
+            title = job.get("title", "")
+            location = job.get("location", {})
+            location_name = location.get("name", "") if isinstance(location, dict) else str(location)
+            url = job.get("absolute_url", "")
+
+            if title and url:
+                postings.append(
+                    {
+                        "title": title.strip(),
+                        "location": location_name.strip(),
+                        "url": url,
+                    }
+                )
+        return postings

--- a/tests/integration/test_ui_states.py
+++ b/tests/integration/test_ui_states.py
@@ -13,9 +13,11 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.db.models import JobPosting, ScrapeRun
+from src.scrapers.scheduler import SCRAPERS
 from src.web.app import create_app
 
-COMPANIES = ("anthropic", "openai", "deepmind")
+COMPANIES = tuple(SCRAPERS.keys())
+TOTAL_COMPANIES = len(COMPANIES)
 
 
 # --- fixtures / factories --------------------------------------------------
@@ -171,7 +173,7 @@ class TestHeroNo:
         assert "siren" in response.text  # the alarm visual
 
     async def test_hero_no_with_two_successful_scrapers(self, client, db_session):
-        """Only two out of three scrapers need to succeed to move from unsure -> no."""
+        """Only two scrapers need to succeed to move from unsure -> no (threshold is >=2)."""
         for company in ("anthropic", "openai"):
             await _seed_run_with_postings(
                 db_session,
@@ -228,7 +230,7 @@ class TestHeroUnsure:
         assert response.status_code == 200
         assert "hero-unsure" in response.text
         assert "Unsure yet, still checking" in response.text
-        assert "0/3 scrapers finished" in response.text
+        assert f"0/{TOTAL_COMPANIES} scrapers finished" in response.text
 
     async def test_hero_unsure_while_scrapers_running(self, client, db_session):
         """Scrapers still running, no postings yet -> hero-unsure with 'running' badge."""
@@ -238,8 +240,8 @@ class TestHeroUnsure:
         response = await client.get("/")
         assert response.status_code == 200
         assert "hero-unsure" in response.text
-        assert "0/3 scrapers finished" in response.text
-        assert "3 running" in response.text
+        assert f"0/{TOTAL_COMPANIES} scrapers finished" in response.text
+        assert f"{TOTAL_COMPANIES} running" in response.text
 
     async def test_hero_unsure_when_only_one_scraper_succeeded(self, client, db_session):
         """One success isn't enough to claim 'NO' — still unsure."""
@@ -251,10 +253,10 @@ class TestHeroUnsure:
         response = await client.get("/")
         assert response.status_code == 200
         assert "hero-unsure" in response.text
-        assert "1/3 scrapers finished" in response.text
+        assert f"1/{TOTAL_COMPANIES} scrapers finished" in response.text
 
     async def test_hero_unsure_when_all_scrapers_failed(self, client, db_session):
-        """All three scrapers failed -> hero-unsure with '3 failed' indicator."""
+        """Every scraper failed -> hero-unsure with N-failed indicator."""
         for company in COMPANIES:
             db_session.add(
                 _make_scrape_run(
@@ -269,8 +271,8 @@ class TestHeroUnsure:
         assert response.status_code == 200
         assert "hero-unsure" in response.text
         assert "Unsure yet, still checking" in response.text
-        assert "3 failed" in response.text
-        assert "0/3 scrapers finished" in response.text
+        assert f"{TOTAL_COMPANIES} failed" in response.text
+        assert f"0/{TOTAL_COMPANIES} scrapers finished" in response.text
 
     async def test_hero_unsure_mixed_company_states(self, client, db_session):
         """One succeeded, one failed, one running -> still unsure, badges reflect mix."""
@@ -292,7 +294,7 @@ class TestHeroUnsure:
         response = await client.get("/")
         assert response.status_code == 200
         assert "hero-unsure" in response.text
-        assert "1/3 scrapers finished" in response.text
+        assert f"1/{TOTAL_COMPANIES} scrapers finished" in response.text
         assert "1 running" in response.text
         assert "1 failed" in response.text
 
@@ -475,7 +477,7 @@ class TestFailureModes:
         assert response.status_code == 200
         # With no JobPosting rows active today, we stay unsure even though scrapes succeeded.
         assert "hero-unsure" in response.text
-        assert "2/3 scrapers finished" in response.text
+        assert f"2/{TOTAL_COMPANIES} scrapers finished" in response.text
         # /scrapes still reflects the raw postings_found value (surfacing dedup activity).
         scrapes = await client.get("/scrapes")
         assert scrapes.status_code == 200

--- a/tests/integration/test_xai_scraper.py
+++ b/tests/integration/test_xai_scraper.py
@@ -1,0 +1,42 @@
+"""Tests for xAI scraper (Greenhouse API)."""
+
+from src.scrapers.xai import XAIScraper
+
+
+def test_xai_parse_greenhouse_response():
+    scraper = XAIScraper()
+    data = {
+        "jobs": [
+            {
+                "id": 5045788007,
+                "title": "Software Engineer - Infrastructure",
+                "location": {"name": "Palo Alto, California, United States"},
+                "absolute_url": "https://job-boards.greenhouse.io/xai/jobs/5045788007",
+            },
+            {
+                "id": 4922800007,
+                "title": "Research Engineer",
+                "location": {"name": "Remote"},
+                "absolute_url": "https://job-boards.greenhouse.io/xai/jobs/4922800007",
+            },
+        ]
+    }
+    postings = scraper.parse_response(data)
+
+    assert len(postings) == 2
+    assert postings[0]["title"] == "Software Engineer - Infrastructure"
+    assert postings[0]["location"] == "Palo Alto, California, United States"
+    assert "5045788007" in postings[0]["url"]
+    assert postings[1]["title"] == "Research Engineer"
+    assert postings[1]["location"] == "Remote"
+
+
+def test_xai_parse_empty():
+    scraper = XAIScraper()
+    assert scraper.parse_response({"jobs": []}) == []
+
+
+def test_xai_parse_missing_fields():
+    scraper = XAIScraper()
+    data = {"jobs": [{"title": "", "location": {}, "absolute_url": ""}]}
+    assert scraper.parse_response(data) == []


### PR DESCRIPTION
## Summary
- Adds an `XAIScraper` that consumes `boards-api.greenhouse.io/v1/boards/xai/jobs` — xAI is on Greenhouse, so the parser mirrors the existing Anthropic / DeepMind scrapers.
- Registers the scraper in `SCRAPERS` and switches `get_todays_scrape_summary` to derive its company list from that registry instead of a hardcoded tuple, so adding more labs only needs a new module.
- Adds fixture-based unit tests (`tests/integration/test_xai_scraper.py`) mirroring the existing Greenhouse scraper tests.
- Updates `README.md`, `Implementation.md`, and `docs/ROADMAP.md` to reflect the new company set.

This is **1 of N** for roadmap item #22 — the remaining candidates (Meta AI / FAIR, Mistral, Cohere, Perplexity, Inflection) stay on the backlog for follow-up PRs.

Refs #22.

## Test plan
- [x] `make test` — 46 integration tests pass (3 new xAI scraper tests included)
- [x] `make lint` — ruff check + format clean
- [x] Pre-commit hooks pass (ruff, ruff-format, integration tests)
- [x] Manual verification against the live Greenhouse board — 234 jobs returned, `XAIScraper.run()` parses all 234 cleanly (titles / locations / URLs look sensible).