### PR TITLE
fix: Pi deployment hygiene - drop container restart, fix systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ podman info | grep graphDriverName  # should now report "overlay"
 Best for Raspberry Pi and older systems. Requires `podman-compose` installed (`pip install podman-compose`).
 
 ```bash
+# Allow user-scope systemd units to keep running after SSH logout.
+# Without this, the stack will stop when you disconnect.
+sudo loginctl enable-linger $USER
+
 # Build images and install systemd service
 make install-compose
 

--- a/podman-compose.prod.yml
+++ b/podman-compose.prod.yml
@@ -10,13 +10,11 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-    restart: always
 
   ollama:
     image: localhost/are-they-hiring-ollama:latest
     env_file: .env
     cpus: ${OLLAMA_CPUS:-3.0}
-    restart: always
 
   web:
     image: localhost/are-they-hiring-web:latest
@@ -26,7 +24,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    restart: always
 
   scraper:
     image: localhost/are-they-hiring-scraper:latest
@@ -34,7 +31,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    restart: always
 
 volumes:
   arethey-db-data:

--- a/podman/systemd/are-they-hiring-compose.service
+++ b/podman/systemd/are-they-hiring-compose.service
@@ -3,13 +3,15 @@ Description=Are They Hiring - All Services (podman-compose)
 After=network-online.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 WorkingDirectory=%h/.config/are-they-hiring
-ExecStartPre=/usr/bin/podman-compose -f compose.yml up -d
-ExecStart=/bin/sleep infinity
+ExecStart=/usr/bin/podman-compose -f compose.yml up -d
 ExecStop=/usr/bin/podman-compose -f compose.yml down
-Restart=always
-RestartSec=10
+TimeoutStartSec=300
+TimeoutStopSec=180
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Three related fixes so the Pi can be cleanly re-deployed from git:

- **Drop `restart: always` from all four services in `podman-compose.prod.yml`.** This was the cause of the 90 s stop hang in #19 — compose-level restart policy fought `podman-compose down`. The systemd unit handles stack-level recovery.
- **Reshape `are-they-hiring-compose.service`.** `Type=oneshot + RemainAfterExit=yes` instead of `Type=simple + /bin/sleep infinity`. Add `TimeoutStopSec=180` (default 90 s was what SIGTERM'd the service). Add `TimeoutStartSec=300` for cold-start Ollama model load (matches the live Pi). Switch `Restart=always` / `RestartSec=10` to `Restart=on-failure` / `RestartSec=30`.
- **Document `sudo loginctl enable-linger $USER`** in the Option A deploy flow. Without it the user-scope stack dies on SSH logout — exactly what was happening before.

Closes / unblocks #19.

## Test plan (validated live on the Pi)

- [x] `make install-compose` overwrites `~/.config/are-they-hiring/compose.yml` and `~/.config/systemd/user/are-they-hiring-compose.service` — md5 changed (`f3cf118d... → 61caa4f0...` for compose, `ed0b2336... → ecc5dcea...` for unit).
- [x] `systemctl --user daemon-reload && systemctl --user restart are-they-hiring-compose.service` — stack started cleanly under the new unit; all four containers up; web serves 200.
- [x] `time systemctl --user stop are-they-hiring-compose.service` — **14.9 s with new config** (vs ~27 s under old `restart: always`); comfortably inside `TimeoutStopSec=180`, no SIGTERM.
- [x] `podman exec are-they-hiring_ollama_1 env | grep OLLAMA_KEEP_ALIVE` — shows `OLLAMA_KEEP_ALIVE=12h` (plus `OLLAMA_NUM_THREADS=2`, `OLLAMA_MODEL=gemma3:270m-it-qat`, `CLASSIFY_CONCURRENCY=2`); `env_file` fix confirmed.
- [x] Linger stays enabled (`Linger=yes`); stack survives SSH logout, matching behaviour user already observed post-`loginctl enable-linger`.

**Note (non-blocking):** Ollama accepts the `OLLAMA_HOST=http://ollama:11434` URL form — it strips the scheme and binds to the resolved container IP. Functionally correct for the only consumer (scraper on the same alias). If we ever add a host port mapping for ollama, split the var or set `OLLAMA_HOST=0.0.0.0:11434` explicitly in the server's environment.