### PR TITLE
feat: add Perplexity scraper

### DIFF
--- a/Implementation.md
+++ b/Implementation.md
@@ -10,7 +10,7 @@
 ## Decision Log
 
 ### 1. Target Companies
-**Decision:** Anthropic, OpenAI, Google DeepMind, xAI (added 2026-04-18)
+**Decision:** Anthropic, OpenAI, Google DeepMind, xAI (added 2026-04-18), Perplexity (added 2026-04-18)
 **Rationale:** The most prominent AI companies making bold claims about AI replacing software engineers. Direct relevance to the project's satirical premise. Additional labs can be added incrementally via the `SCRAPERS` registry; see roadmap item 6 for the remaining candidates.
 
 ### 2. Frontend Technology
@@ -28,6 +28,7 @@
 - OpenAI: Ashby API (`api.ashbyhq.com/posting-api/job-board/openai`)
 - DeepMind: Greenhouse API (`boards-api.greenhouse.io/v1/boards/deepmind/jobs`)
 - xAI: Greenhouse API (`boards-api.greenhouse.io/v1/boards/xai/jobs`)
+- Perplexity: Ashby API (`api.ashbyhq.com/posting-api/job-board/perplexity`)
 **Rationale:** JSON APIs are faster, lighter (no browser/Chromium needed), more reliable, and return structured data. The scraper container went from ~1.3GB (with Chromium) to ~580MB. Playwright is no longer a runtime dependency for scraping.
 
 ### 4. Job Title Classification
@@ -102,11 +103,11 @@
 │  │  APScheduler, runs 3x daily      │             │
 │  │  Pipeline: fetch → classify      │             │
 │  │                                  │             │
-│  │  ┌─────────┐┌────────┐┌───────┐┌────┐│             │
-│  │  │Anthropic││OpenAI  ││DeepMind││xAI ││             │
-│  │  │Greenhouse│Ashby   ││Greenhouse│Greenhouse│             │
-│  │  │  API    ││  API   ││  API  ││ API││             │
-│  │  └─────────┘└────────┘└───────┘└────┘│             │
+│  │  ┌─────────┐┌────────┐┌───────┐┌────┐┌──────────┐│             │
+│  │  │Anthropic││OpenAI  ││DeepMind││xAI ││Perplexity││             │
+│  │  │Greenhouse│Ashby   ││Greenhouse│Greenhouse│Ashby │             │
+│  │  │  API    ││  API   ││  API  ││ API││  API     ││             │
+│  │  └─────────┘└────────┘└───────┘└────┘└──────────┘│             │
 │  └──────────────────────────────────┘             │
 │                                          :8000 ──►│
 └────────────────────────────────────────────────────┘
@@ -122,7 +123,7 @@ All containers communicate over the pod's shared network.
 | Column           | Type      | Notes                                    |
 |------------------|-----------|------------------------------------------|
 | id               | UUID      | Primary key                              |
-| company          | VARCHAR   | anthropic / openai / deepmind / xai       |
+| company          | VARCHAR   | anthropic / openai / deepmind / xai / perplexity       |
 | status           | VARCHAR   | running / success / failed               |
 | started_at       | TIMESTAMP |                                          |
 | finished_at      | TIMESTAMP | Nullable                                 |
@@ -138,7 +139,7 @@ All containers communicate over the pod's shared network.
 |------------------------|-----------|----------------------------------------|
 | id                     | UUID      | Primary key                            |
 | scrape_run_id          | UUID      | FK to scrape_runs                      |
-| company                | VARCHAR   | anthropic / openai / deepmind / xai    |
+| company                | VARCHAR   | anthropic / openai / deepmind / xai / perplexity    |
 | title                  | VARCHAR   | Original job title                     |
 | location               | VARCHAR   |                                        |
 | url                    | VARCHAR   | Link to original posting               |
@@ -240,10 +241,11 @@ OLLAMA_HOST=http://localhost:11434
 CLASSIFY_CONCURRENCY=4
 
 # Company APIs (auto-configured, override if needed)
-# Anthropic: boards-api.greenhouse.io/v1/boards/anthropic/jobs
-# OpenAI:    api.ashbyhq.com/posting-api/job-board/openai
-# DeepMind:  boards-api.greenhouse.io/v1/boards/deepmind/jobs
-# xAI:       boards-api.greenhouse.io/v1/boards/xai/jobs
+# Anthropic:  boards-api.greenhouse.io/v1/boards/anthropic/jobs
+# OpenAI:     api.ashbyhq.com/posting-api/job-board/openai
+# DeepMind:   boards-api.greenhouse.io/v1/boards/deepmind/jobs
+# xAI:        boards-api.greenhouse.io/v1/boards/xai/jobs
+# Perplexity: api.ashbyhq.com/posting-api/job-board/perplexity
 ```
 
 ---
@@ -309,6 +311,7 @@ are-they-hiring/
 │   │   ├── openai_scraper.py          # Ashby API parser
 │   │   ├── deepmind.py                # Greenhouse API parser
 │   │   ├── xai.py                     # Greenhouse API parser
+│   │   ├── perplexity.py              # Ashby API parser (thin subclass of openai_scraper)
 │   │   └── scheduler.py               # fetch/classify/reclassify + APScheduler
 │   └── web/
 │       ├── app.py                     # FastAPI app factory + routes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Are They Still Hiring Software Engineers?
 
-A satirical web app that scrapes job postings from Anthropic, OpenAI, Google DeepMind, and xAI, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
+A satirical web app that scrapes job postings from Anthropic, OpenAI, Google DeepMind, xAI, and Perplexity, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
 
 > **Contributing?** Read [`AGENTS.md`](AGENTS.md) first — it lays out the repo conventions (branches, commits, tests, docs) both humans and AI agents should follow.
 
@@ -25,7 +25,7 @@ podman-compose -f podman-compose.dev.yml up -d
 open http://localhost:8000
 ```
 
-The web container auto-runs database migrations on startup. The scraper fetches from all 4 company APIs and classifies titles via Ollama immediately, then on the configured schedule.
+The web container auto-runs database migrations on startup. The scraper fetches from all 5 company APIs and classifies titles via Ollama immediately, then on the configured schedule.
 
 ### Port Mappings
 
@@ -275,7 +275,7 @@ Ollama (gemma3:270m, CPU/GPU) → Classification
 ```
 
 - **Web**: FastAPI serves HTMX/Jinja2 pages with Chart.js and confetti
-- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind, xAI) and Ashby (OpenAI) JSON APIs
+- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind, xAI) and Ashby (OpenAI, Perplexity) JSON APIs
 - **Classifier**: Parallel Ollama requests to classify job titles as SWE or not
 - **Database**: PostgreSQL with deduplication by (company, URL), first/last seen tracking
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,7 +129,7 @@ Also re-validate the Playwright E2E suite as part of this work — it hasn't bee
 - Meta AI (FAIR)
 - Mistral
 - Cohere
-- Perplexity
+- ~~Perplexity~~ (done — Ashby scraper landed 2026-04-18)
 - Inflection (if still hiring independently)
 
 **Shape:**

--- a/src/scrapers/perplexity.py
+++ b/src/scrapers/perplexity.py
@@ -1,0 +1,6 @@
+from src.scrapers.openai_scraper import OpenAIScraper
+
+
+class PerplexityScraper(OpenAIScraper):
+    company = "perplexity"
+    api_url = "https://api.ashbyhq.com/posting-api/job-board/perplexity"

--- a/src/scrapers/scheduler.py
+++ b/src/scrapers/scheduler.py
@@ -15,6 +15,7 @@ from src.db.session import get_session_factory
 from src.scrapers.anthropic import AnthropicScraper
 from src.scrapers.deepmind import DeepMindScraper
 from src.scrapers.openai_scraper import OpenAIScraper
+from src.scrapers.perplexity import PerplexityScraper
 from src.scrapers.xai import XAIScraper
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,7 @@ SCRAPERS = {
     "openai": OpenAIScraper,
     "deepmind": DeepMindScraper,
     "xai": XAIScraper,
+    "perplexity": PerplexityScraper,
 }
 
 

--- a/tests/integration/test_perplexity_scraper.py
+++ b/tests/integration/test_perplexity_scraper.py
@@ -1,0 +1,54 @@
+"""Tests for Perplexity scraper (Ashby API)."""
+
+from src.scrapers.perplexity import PerplexityScraper
+
+
+def test_perplexity_parse_ashby_response():
+    scraper = PerplexityScraper()
+    data = {
+        "jobs": [
+            {
+                "id": "638e6823-be7f-46c6-9675-7b1197fc9b8c",
+                "title": "Engineering Site Lead",
+                "location": "London",
+                "department": "Engineering",
+                "jobUrl": "https://jobs.ashbyhq.com/perplexity/638e6823-be7f-46c6-9675-7b1197fc9b8c",
+            },
+            {
+                "id": "1dc97d9e-565e-4079-9fba-40fab14a3602",
+                "title": "Member of Technical Staff (iOS Software Engineer)",
+                "location": "San Francisco",
+                "department": "Engineering",
+                "jobUrl": "https://jobs.ashbyhq.com/perplexity/1dc97d9e-565e-4079-9fba-40fab14a3602",
+            },
+        ]
+    }
+    postings = scraper.parse_response(data)
+
+    assert len(postings) == 2
+    assert postings[0]["title"] == "Engineering Site Lead"
+    assert postings[0]["location"] == "London"
+    assert "638e6823" in postings[0]["url"]
+    assert postings[1]["title"] == "Member of Technical Staff (iOS Software Engineer)"
+    assert postings[1]["location"] == "San Francisco"
+
+
+def test_perplexity_parse_empty():
+    scraper = PerplexityScraper()
+    assert scraper.parse_response({"jobs": []}) == []
+
+
+def test_perplexity_parse_missing_location():
+    scraper = PerplexityScraper()
+    data = {
+        "jobs": [
+            {
+                "title": "SWE",
+                "location": None,
+                "jobUrl": "https://jobs.ashbyhq.com/perplexity/x",
+            },
+        ]
+    }
+    postings = scraper.parse_response(data)
+    assert len(postings) == 1
+    assert postings[0]["location"] == ""


### PR DESCRIPTION
## Summary

- Adds a Perplexity scraper using the Ashby job board API (`https://api.ashbyhq.com/posting-api/job-board/perplexity`).
- `PerplexityScraper` is a thin subclass of `OpenAIScraper` — same Ashby response shape (`title`, `location`, `jobUrl`), only the board name differs.
- Registered under `"perplexity"` in `SCRAPERS`; `get_todays_scrape_summary`, `fetch_all`, and the classifier pipeline pick it up automatically via the registry (unchanged since the xAI refactor).
- Fixture-based integration test mirrors `test_openai_scraper.py`.
- Docs updated: `README.md`, `Implementation.md`, and `docs/ROADMAP.md` (item 6 candidates list).

Manual verification against the live endpoint returned 74 jobs. Sample titles:
- Engineering Site Lead — London
- Member of Technical Staff (iOS Software Engineer) — San Francisco
- Member of Technical Staff (AI Inference Engineer) — San Francisco
- Member of Technical Staff (Cloud Security Engineer) — San Francisco
- Member of Technical Staff (Backend/Infrastructure Engineer, Search) — Belgrade

This is **3 of N** for roadmap item #22 (xAI was 1; Meta AI is running in parallel as 2). Expect merge conflicts in `docs/ROADMAP.md`, `README.md`, `Implementation.md`, and `src/scrapers/scheduler.py` with the Meta AI PR — whichever merges second will need a trivial rebase.

Refs #22

## Test plan

- [x] `uv run pytest tests/integration/` — 73 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] Pre-commit hooks (ruff + ruff-format + integration tests) pass
- [x] Live endpoint returns 200 with 74 jobs in expected Ashby shape