### PR TITLE
feat: add Meta AI (FAIR) scraper

### DIFF
--- a/Implementation.md
+++ b/Implementation.md
@@ -2,7 +2,7 @@
 
 **Project:** are-they-still-hiring-software-engineers.com
 **Initial design:** 2026-03-13
-**Last updated:** 2026-04-05
+**Last updated:** 2026-04-18
 **Status:** Implemented, running in dev environment
 
 ---
@@ -10,7 +10,7 @@
 ## Decision Log
 
 ### 1. Target Companies
-**Decision:** Anthropic, OpenAI, Google DeepMind, xAI (added 2026-04-18), Perplexity (added 2026-04-18)
+**Decision:** Anthropic, OpenAI, Google DeepMind, xAI (added 2026-04-18), Perplexity (added 2026-04-18), Meta AI / FAIR (added 2026-04-18)
 **Rationale:** The most prominent AI companies making bold claims about AI replacing software engineers. Direct relevance to the project's satirical premise. Additional labs can be added incrementally via the `SCRAPERS` registry; see roadmap item 6 for the remaining candidates.
 
 ### 2. Frontend Technology
@@ -29,6 +29,7 @@
 - DeepMind: Greenhouse API (`boards-api.greenhouse.io/v1/boards/deepmind/jobs`)
 - xAI: Greenhouse API (`boards-api.greenhouse.io/v1/boards/xai/jobs`)
 - Perplexity: Ashby API (`api.ashbyhq.com/posting-api/job-board/perplexity`)
+- Meta AI / FAIR: metacareers GraphQL (`metacareers.com/graphql` with `doc_id=9114524511922157`, filtered to the "Artificial Intelligence" team). More fragile than Greenhouse/Ashby — if Meta rebuilds their frontend the `doc_id` changes — but the only usable JSON surface on metacareers.com.
 **Rationale:** JSON APIs are faster, lighter (no browser/Chromium needed), more reliable, and return structured data. The scraper container went from ~1.3GB (with Chromium) to ~580MB. Playwright is no longer a runtime dependency for scraping.
 
 ### 4. Job Title Classification
@@ -123,7 +124,7 @@ All containers communicate over the pod's shared network.
 | Column           | Type      | Notes                                    |
 |------------------|-----------|------------------------------------------|
 | id               | UUID      | Primary key                              |
-| company          | VARCHAR   | anthropic / openai / deepmind / xai / perplexity       |
+| company          | VARCHAR   | anthropic / openai / deepmind / xai / perplexity / meta       |
 | status           | VARCHAR   | running / success / failed               |
 | started_at       | TIMESTAMP |                                          |
 | finished_at      | TIMESTAMP | Nullable                                 |
@@ -139,7 +140,7 @@ All containers communicate over the pod's shared network.
 |------------------------|-----------|----------------------------------------|
 | id                     | UUID      | Primary key                            |
 | scrape_run_id          | UUID      | FK to scrape_runs                      |
-| company                | VARCHAR   | anthropic / openai / deepmind / xai / perplexity    |
+| company                | VARCHAR   | anthropic / openai / deepmind / xai / perplexity / meta    |
 | title                  | VARCHAR   | Original job title                     |
 | location               | VARCHAR   |                                        |
 | url                    | VARCHAR   | Link to original posting               |
@@ -246,6 +247,7 @@ CLASSIFY_CONCURRENCY=4
 # DeepMind:   boards-api.greenhouse.io/v1/boards/deepmind/jobs
 # xAI:        boards-api.greenhouse.io/v1/boards/xai/jobs
 # Perplexity: api.ashbyhq.com/posting-api/job-board/perplexity
+# Meta AI:    metacareers.com/graphql (POST, doc_id 9114524511922157, teams=["Artificial Intelligence"])
 ```
 
 ---
@@ -312,6 +314,7 @@ are-they-hiring/
 │   │   ├── deepmind.py                # Greenhouse API parser
 │   │   ├── xai.py                     # Greenhouse API parser
 │   │   ├── perplexity.py              # Ashby API parser (thin subclass of openai_scraper)
+│   │   ├── meta_ai.py                  # metacareers GraphQL parser (doc_id persisted-query)
 │   │   └── scheduler.py               # fetch/classify/reclassify + APScheduler
 │   └── web/
 │       ├── app.py                     # FastAPI app factory + routes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Are They Still Hiring Software Engineers?
 
-A satirical web app that scrapes job postings from Anthropic, OpenAI, Google DeepMind, xAI, and Perplexity, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
+A satirical web app that scrapes job postings from Anthropic, OpenAI, Google DeepMind, xAI, Perplexity, and Meta AI, classifies them using a local LLM, and displays whether Big AI is still hiring software engineers — with a countdown since Dario Amodei claimed AI would replace all software engineers.
 
 > **Contributing?** Read [`AGENTS.md`](AGENTS.md) first — it lays out the repo conventions (branches, commits, tests, docs) both humans and AI agents should follow.
 
@@ -275,7 +275,7 @@ Ollama (gemma3:270m, CPU/GPU) → Classification
 ```
 
 - **Web**: FastAPI serves HTMX/Jinja2 pages with Chart.js and confetti
-- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind, xAI) and Ashby (OpenAI, Perplexity) JSON APIs
+- **Scraper**: Fetches from Greenhouse (Anthropic, DeepMind, xAI), Ashby (OpenAI, Perplexity), and metacareers GraphQL (Meta AI — filtered to the Artificial Intelligence team)
 - **Classifier**: Parallel Ollama requests to classify job titles as SWE or not
 - **Database**: PostgreSQL with deduplication by (company, URL), first/last seen tracking
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -126,7 +126,7 @@ Also re-validate the Playwright E2E suite as part of this work — it hasn't bee
 
 **Candidates:**
 - ~~xAI~~ (done — Greenhouse scraper landed 2026-04-18)
-- Meta AI (FAIR)
+- ~~Meta AI (FAIR)~~ (done — metacareers GraphQL scraper landed 2026-04-18)
 - Mistral
 - Cohere
 - ~~Perplexity~~ (done — Ashby scraper landed 2026-04-18)

--- a/src/scrapers/meta_ai.py
+++ b/src/scrapers/meta_ai.py
@@ -1,0 +1,67 @@
+import json
+
+import httpx
+
+from src.scrapers.base import BaseScraper
+
+
+class MetaAIScraper(BaseScraper):
+    company = "meta"
+    api_url = "https://www.metacareers.com/graphql"
+
+    # Meta's careers frontend issues a GraphQL "CareersJobSearchResultsQuery" against
+    # this endpoint. `doc_id` is the persisted-query hash published by their bundle.
+    # If Meta changes the hash, fetches will 4xx — the scrape_runs table captures that.
+    _doc_id = "9114524511922157"
+    _search_input = {
+        "q": "",
+        "teams": ["Artificial Intelligence"],
+        "offices": [],
+        "divisions": [],
+        "roles": [],
+        "leadership_levels": [],
+        "is_leadership": False,
+        "is_in_page": False,
+        "sub_teams": [],
+    }
+
+    async def run(self) -> list[dict]:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                self.api_url,
+                headers={"User-Agent": "AreTheyHiringBot/1.0"},
+                data={
+                    "fb_dtsg": "",
+                    "doc_id": self._doc_id,
+                    "variables": json.dumps({"search_input": self._search_input}),
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+        return self.parse_response(data)
+
+    def parse_response(self, data: dict | list) -> list[dict]:
+        if not isinstance(data, dict):
+            return []
+        jobs = (data.get("data") or {}).get("job_search") or []
+        postings = []
+        for job in jobs:
+            title = (job.get("title") or "").strip()
+            job_id = str(job.get("id") or "").strip()
+            if not title or not job_id:
+                continue
+            locations = job.get("locations") or []
+            if not locations:
+                location = "Unlisted"
+            elif len(locations) == 1:
+                location = locations[0]
+            else:
+                location = f"{locations[0]} (+{len(locations) - 1} more)"
+            postings.append(
+                {
+                    "title": title,
+                    "location": location,
+                    "url": f"https://www.metacareers.com/jobs/{job_id}/",
+                }
+            )
+        return postings

--- a/src/scrapers/scheduler.py
+++ b/src/scrapers/scheduler.py
@@ -14,6 +14,7 @@ from src.db.queries import upsert_postings
 from src.db.session import get_session_factory
 from src.scrapers.anthropic import AnthropicScraper
 from src.scrapers.deepmind import DeepMindScraper
+from src.scrapers.meta_ai import MetaAIScraper
 from src.scrapers.openai_scraper import OpenAIScraper
 from src.scrapers.perplexity import PerplexityScraper
 from src.scrapers.xai import XAIScraper
@@ -26,6 +27,7 @@ SCRAPERS = {
     "deepmind": DeepMindScraper,
     "xai": XAIScraper,
     "perplexity": PerplexityScraper,
+    "meta": MetaAIScraper,
 }
 
 

--- a/tests/integration/test_meta_ai_scraper.py
+++ b/tests/integration/test_meta_ai_scraper.py
@@ -1,0 +1,57 @@
+"""Tests for Meta AI scraper (metacareers.com GraphQL)."""
+
+from src.scrapers.meta_ai import MetaAIScraper
+
+
+def test_meta_ai_parse_graphql_response():
+    scraper = MetaAIScraper()
+    data = {
+        "data": {
+            "job_search": [
+                {
+                    "id": "1436181490732782",
+                    "title": "Software Engineer, Machine Learning",
+                    "locations": ["Menlo Park, CA", "New York, NY", "Remote, US"],
+                    "teams": ["Artificial Intelligence"],
+                },
+                {
+                    "id": "807341018406296",
+                    "title": "Research Engineer",
+                    "locations": ["Singapore"],
+                    "teams": ["Artificial Intelligence"],
+                },
+            ]
+        }
+    }
+    postings = scraper.parse_response(data)
+
+    assert len(postings) == 2
+    assert postings[0]["title"] == "Software Engineer, Machine Learning"
+    assert postings[0]["location"] == "Menlo Park, CA (+2 more)"
+    assert postings[0]["url"] == "https://www.metacareers.com/jobs/1436181490732782/"
+    assert postings[1]["title"] == "Research Engineer"
+    assert postings[1]["location"] == "Singapore"
+
+
+def test_meta_ai_parse_empty():
+    scraper = MetaAIScraper()
+    assert scraper.parse_response({"data": {"job_search": []}}) == []
+    assert scraper.parse_response({}) == []
+    assert scraper.parse_response([]) == []
+
+
+def test_meta_ai_parse_missing_fields():
+    scraper = MetaAIScraper()
+    data = {
+        "data": {
+            "job_search": [
+                {"id": "", "title": "No id", "locations": []},
+                {"id": "123", "title": "", "locations": ["Menlo Park, CA"]},
+                {"id": "456", "title": "Unlisted location role", "locations": None},
+            ]
+        }
+    }
+    postings = scraper.parse_response(data)
+    assert len(postings) == 1
+    assert postings[0]["title"] == "Unlisted location role"
+    assert postings[0]["location"] == "Unlisted"


### PR DESCRIPTION
## Summary

Adds a Meta AI / FAIR scraper against metacareers.com. Registers the scraper in \`SCRAPERS\` — the registry-driven summary query added with xAI picks it up automatically.

## Why it looks different

Meta does not use Greenhouse or Ashby. Their careers site runs its own GraphQL backend. The working approach:

- POST to \`https://www.metacareers.com/graphql\`, form-encoded
- \`doc_id=9114524511922157\` (the persisted-query hash the frontend ships for \`CareersJobSearchResultsQuery\`)
- \`variables={"search_input":{"teams":["Artificial Intelligence"], ...}}\` — pre-filters to the AI / FAIR team at the API level so we don't pull thousands of unrelated Meta roles

Returns ~100 AI/FAIR roles per call. Manual verification: 99 jobs, 46 with "engineer" in the title.

Because the request shape is POST rather than GET, \`MetaAIScraper\` overrides \`BaseScraper.run()\`. \`parse_response\` is the usual dict-to-posting mapping.

Sample parsed rows:
- \`Business Engineer - Business AI\` — Singapore
- \`Software Engineer, Machine Learning\` — Sunnyvale, CA (+14 more)
- \`Research Engineer, Monetization AI\` — Sunnyvale, CA (+5 more)

Locations arrive as a list per posting; I collapse multi-location roles to \`\"first (+N more)\"\` so they stay within the 200-char \`location\` column.

## Known fragility

If Meta rebuilds their careers frontend, the \`doc_id\` hash changes and fetches will 4xx. \`scrape_runs\` already captures that, and classification still runs for the other five companies in the meantime. Noted in the scraper file.

## This is 3 of N for #22

- xAI — #28 (merged)
- Perplexity — #33 (merged)
- **Meta AI / FAIR — this PR**
- Mistral, Cohere, Inflection — backlog

Refs #22.

## Test plan

- [x] \`uv run pytest tests/integration/\` — 76 passed (3 new Meta AI fixture tests)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format --check src/ tests/\` — clean
- [x] Pre-commit hooks pass (ruff, ruff-format, integration tests)
- [x] Manual live fetch against metacareers.com — 99 AI/FAIR jobs returned