### PR TITLE
feat: profile-based deployment config renderer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,13 +24,13 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run ruff linter (auto-fix)
-        run: uv run ruff check --fix src/ tests/
+        run: uv run ruff check --fix src/ tests/ deploy/
 
       - name: Run ruff formatter
-        run: uv run ruff format src/ tests/
+        run: uv run ruff format src/ tests/ deploy/
 
       - name: Sort dependencies in pyproject.toml
-        run: uv run ruff check --select I --fix src/ tests/
+        run: uv run ruff check --select I --fix src/ tests/ deploy/
 
       - name: Commit fixes if any
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run integration tests
-        run: uv run pytest tests/integration/ -v
+      - name: Run unit + integration tests
+        run: uv run pytest tests/unit/ tests/integration/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build/
 .pytest_cache/
 .mypy_cache/
 .superpowers/
+# Deploy renderer staging + secrets (never committed)
+deploy/staging/
+secrets.env
+*.secrets.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
   - repo: local
     hooks:
       - id: tests
-        name: integration tests
-        entry: uv run pytest tests/integration/ -q
+        name: unit + integration tests
+        entry: uv run pytest tests/unit/ tests/integration/ -q
         language: system
         pass_filenames: false
         always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ Rules for AI agents (and humans following the same conventions) working in this 
 
 ## 3. Tests and linting
 
-- Run `make test` before pushing. 40+ integration tests, all SQLite in-memory. No external services required.
-- Run `make lint` to check formatting. `make lint-fix` auto-fixes.
+- Run `make test` before pushing. Runs `tests/unit/` (renderer / schema golden tests) and `tests/integration/` (scrapers, API, DB — all SQLite in-memory). No external services required.
+- Run `make lint` to check formatting (covers `src/`, `tests/`, `deploy/`). `make lint-fix` auto-fixes.
 - All new behaviour needs a test. Bug fixes need a regression test.
 - CI runs tests + lint on every PR. The lint job will commit auto-fixes back to the branch; after that, `git pull` your branch before pushing again.
 

--- a/Implementation.md
+++ b/Implementation.md
@@ -86,6 +86,14 @@
 - **Unsure** (amber + "..."): Scrapers still running or insufficient data. Shows X/3 scrapers finished, auto-refreshes every 10s.
 **Rationale:** Prevents misleading "NO" when scrapers haven't run yet today.
 
+### 13a. Profile-based deployment renderer (added 2026-04-18)
+**Decision:** Deployment config (per-env values, compose structure, systemd unit) is consolidated behind a profile-based Jinja2 renderer (`deploy/render.py`). Each environment (Pi, future VPS) has a `deploy/profiles/<name>.yml` validated by a pydantic schema; three templates under `deploy/templates/` render it into `.env`, `compose.yml`, and the `are-they-hiring-compose.service` systemd unit. Apply is done via `make deploy PROFILE=<name>` (local) or `make deploy PROFILE=<name> HOST=user@host` (remote over `ssh`/`scp`).
+**Rationale:** Previously, adding a single tuning knob (e.g. `CPUWeight`, `cpu_shares`) touched 2–3 files, and `make install-compose` didn't touch existing `.env`s — stale defaults on the Pi caused a silent regression during PR #35's rollout (the Pi kept using `gemma3:270m-it-qat` because the repo `.env.example` update never reached the live `.env`). One profile = one source of truth.
+**Secrets handling:** Profile carries a `secrets_env_path` pointer; the renderer merges that file into the rendered `.env` at apply time only, so the committed artefacts never contain secrets. Future upgrade path: sops/age.
+**Golden tests:** `tests/unit/test_render.py` pins rendered output against `deploy/testdata/pi-expected/`, and also verifies that a default-ish profile reproduces today's `.env.example`/`compose.prod.yml`/`.service` byte-for-byte — guaranteeing existing deployments see zero drift when migrating to the renderer.
+**First use case:** "Deprioritize Ollama vs OS" CPU tuning landed as a profile-only diff (`cpu_weight: 10`, `io_weight: 10`, `nice: 15` at the systemd level; `cpu_shares: 128` and `cpus: null` on the Ollama container) with no code/compose/unit edits.
+**Legacy target kept:** `make install-compose` still works, with a deprecation notice, so partial migrations don't break.
+
 ### 13. Collapsible Job Listings (added 2026-04-05)
 **Decision:** Day detail page shows company sections collapsed by default. Click to expand and see the full job table.
 **Rationale:** The summary (company name + posting count) is more useful at a glance than hundreds of rows.
@@ -308,6 +316,16 @@ are-they-hiring/
 │       ├── are-they-hiring-db.container
 │       ├── are-they-hiring-ollama.container
 │       └── are-they-hiring-scraper.container
+├── deploy/                            # Profile-based deployment renderer
+│   ├── render.py                      # CLI: --profile <name> render|apply [--host ...]
+│   ├── profiles/
+│   │   └── pi.yml                     # Pi profile (source of truth for all per-env values)
+│   ├── templates/
+│   │   ├── env.j2
+│   │   ├── compose.prod.yml.j2
+│   │   └── are-they-hiring-compose.service.j2
+│   └── testdata/
+│       └── pi-expected/               # Golden output for rendered-file regression tests
 ├── src/
 │   ├── config.py                      # Pydantic settings from .env
 │   ├── db/
@@ -332,7 +350,8 @@ are-they-hiring/
 │       └── static/                    # CSS, JS, sound placeholders
 ├── tests/
 │   ├── conftest.py                    # SQLite in-memory db_session fixture
-│   ├── integration/                   # 40 tests (scrapers, classifier, API, DB, scheduler)
+│   ├── unit/                          # Pure-Python unit tests (renderer golden-output, schema)
+│   ├── integration/                   # 40+ tests (scrapers, classifier, API, DB, scheduler)
 │   ├── e2e/                           # Playwright browser tests
 │   └── fixtures/
 │       ├── html_snapshots/            # (legacy, from Playwright era)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: test test-e2e migrate revision lint lint-fix build build-all build-container-web build-container-scraper build-container-ollama run clean test-env-up test-env-down fetch classify reclassify dev install uninstall install-compose uninstall-compose
+.PHONY: test test-e2e migrate revision lint lint-fix build build-all build-container-web build-container-scraper build-container-ollama run clean test-env-up test-env-down fetch classify reclassify dev install uninstall install-compose uninstall-compose deploy deploy-render
 
 test:
-	uv run pytest tests/integration/ -v
+	uv run pytest tests/unit/ tests/integration/ -v
 
 test-e2e:
 	uv run pytest tests/e2e/ -v
@@ -13,12 +13,12 @@ revision:
 	uv run alembic revision --autogenerate -m "$(msg)"
 
 lint:
-	uv run ruff check src/ tests/
-	uv run ruff format --check src/ tests/
+	uv run ruff check src/ tests/ deploy/
+	uv run ruff format --check src/ tests/ deploy/
 
 lint-fix:
-	uv run ruff check --fix src/ tests/
-	uv run ruff format src/ tests/
+	uv run ruff check --fix src/ tests/ deploy/
+	uv run ruff format src/ tests/ deploy/
 
 build-container-web:
 	podman build -f Containerfile.web -t are-they-hiring-web .
@@ -81,6 +81,11 @@ uninstall:
 	@echo "Units removed. Data volume and .env preserved."
 
 install-compose: build-all
+	@echo ""
+	@echo "*** DEPRECATED: 'make install-compose' is being replaced by     ***"
+	@echo "*** 'make deploy PROFILE=<name>'. See deploy/profiles/ for       ***"
+	@echo "*** per-environment config. This target still works for now.    ***"
+	@echo ""
 	@echo "Installing compose-based systemd service..."
 	mkdir -p $(HOME)/.config/are-they-hiring
 	cp podman-compose.prod.yml $(HOME)/.config/are-they-hiring/compose.yml
@@ -96,6 +101,29 @@ install-compose: build-all
 	systemctl --user daemon-reload
 	@echo "Done. Start with: systemctl --user start are-they-hiring-compose.service"
 	@echo "Enable on boot: systemctl --user enable are-they-hiring-compose.service"
+
+# --- Profile-based deployment (issue #37) -----------------------------
+# Usage:
+#   make deploy-render PROFILE=pi                  # render + diff, no apply
+#   make deploy PROFILE=pi                         # render + apply locally
+#   make deploy PROFILE=pi HOST=user@192.168.1.2   # render + apply over SSH
+#
+# Profiles live in deploy/profiles/<name>.yml.
+
+PROFILE ?=
+HOST ?=
+
+deploy-render:
+	@if [ -z "$(PROFILE)" ]; then echo "Usage: make deploy-render PROFILE=<name>"; exit 2; fi
+	uv run python -m deploy.render --profile $(PROFILE) render
+
+deploy:
+	@if [ -z "$(PROFILE)" ]; then echo "Usage: make deploy PROFILE=<name> [HOST=user@host]"; exit 2; fi
+	@if [ -n "$(HOST)" ]; then \
+		uv run python -m deploy.render --profile $(PROFILE) apply --host $(HOST); \
+	else \
+		uv run python -m deploy.render --profile $(PROFILE) apply; \
+	fi
 
 uninstall-compose:
 	systemctl --user stop are-they-hiring-compose.service 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -206,26 +206,50 @@ podman info | grep graphDriverName  # should now report "overlay"
 
 Best for Raspberry Pi and older systems. Requires `podman-compose` installed (`pip install podman-compose`).
 
+#### Profile-based deploy (recommended)
+
+Per-environment configuration lives in `deploy/profiles/<name>.yml` and is rendered into the `.env`, `compose.yml`, and systemd unit via Jinja2 templates. Secrets stay in a separate file outside the repo (`secrets_env_path:` in the profile, pointing at e.g. `~/.config/are-they-hiring/secrets.env`).
+
 ```bash
 # Allow user-scope systemd units to keep running after SSH logout.
-# Without this, the stack will stop when you disconnect.
 sudo loginctl enable-linger $USER
 
-# Build images and install systemd service
-make install-compose
+# Build images first (one-off)
+make build-all
 
-# Edit .env with real credentials
-nano ~/.config/are-they-hiring/.env
+# Preview what will be deployed (renders + diffs, does not apply)
+make deploy-render PROFILE=pi
 
-# Start and enable on boot
-systemctl --user start are-they-hiring-compose.service
-systemctl --user enable are-they-hiring-compose.service
+# Apply locally (renders, writes to ~/.config/..., reloads + restarts)
+make deploy PROFILE=pi
+
+# Or deploy over SSH from your dev machine to the Pi
+make deploy PROFILE=pi HOST=cfiet@192.168.1.2
 
 # View logs
 journalctl --user -u are-they-hiring-compose.service -f
 
 # Uninstall (preserves data and .env)
 make uninstall-compose
+```
+
+The renderer:
+- Validates the profile against a pydantic schema (typos in YAML fail fast).
+- Merges in secrets from `secrets_env_path` at apply time (never templated into committed files).
+- Warns if the live `.env` has orphan keys that aren't in the profile.
+- Refuses to overwrite if the live `compose.yml` or systemd unit has been hand-edited since the repo's last commit.
+
+See `deploy/profiles/pi.yml` for the current Pi profile — that's where you tweak `OLLAMA_MODEL`, CPU prioritisation, scrape schedule, etc.
+
+#### Legacy flow (deprecated)
+
+`make install-compose` still works but is deprecated — it copies the static `podman-compose.prod.yml` and `.env.example` without any env-specific rendering.
+
+```bash
+make install-compose
+nano ~/.config/are-they-hiring/.env
+systemctl --user start are-they-hiring-compose.service
+systemctl --user enable are-they-hiring-compose.service
 ```
 
 ### Option B: Quadlet units (requires Podman 4.4+)

--- a/deploy/profiles/pi.yml
+++ b/deploy/profiles/pi.yml
@@ -1,0 +1,51 @@
+# Raspberry Pi deployment profile.
+#
+# One source of truth for the Pi's env-specific values. Rendered into:
+#   - ~/.config/are-they-hiring/.env
+#   - ~/.config/are-they-hiring/compose.yml
+#   - ~/.config/systemd/user/are-they-hiring-compose.service
+# by `python -m deploy.render --profile pi apply` (or `make deploy PROFILE=pi`).
+
+host: cfiet@192.168.1.2
+
+tz: UTC
+
+# Secrets (DB password etc.) live outside the repo. The renderer merges this
+# file into the rendered .env at apply time without templating anything.
+# Minimum contents on the Pi:
+#   POSTGRES_PASSWORD=<real password>
+#   DATABASE_URL=postgresql+asyncpg://arethey:<real password>@localhost:5432/arethey
+secrets_env_path: ~/.config/are-they-hiring/secrets.env
+
+postgres:
+  user: arethey
+  password: CHANGE_ME_TO_A_STRONG_PASSWORD
+  db: arethey
+  database_url: postgresql+asyncpg://arethey:CHANGE_ME_TO_A_STRONG_PASSWORD@localhost:5432/arethey
+
+ollama:
+  host: http://ollama:11434
+  model: qwen2.5:1.5b
+  keep_alive: 12h
+  num_threads: 2
+  timeout_seconds: 300
+  # null means no CPU cap on the Ollama container — we instead use cpu_shares
+  # below (and CPUWeight at the systemd level) so Ollama yields to the rest
+  # of the stack and to the OS under contention.
+  cpus: null
+  cpu_shares: 128
+
+classify:
+  concurrency: 2
+
+scrape:
+  schedule: "06:00,12:00,18:00"
+  retry_max: 3
+
+systemd:
+  # The whole stack yields to the OS under contention.
+  cpu_weight: 10
+  io_weight: 10
+  nice: 15
+  timeout_start_sec: 300
+  timeout_stop_sec: 180

--- a/deploy/render.py
+++ b/deploy/render.py
@@ -1,0 +1,459 @@
+"""Profile-based deployment config renderer.
+
+Reads a YAML profile from ``deploy/profiles/<name>.yml``, validates it against
+a pydantic schema, renders three Jinja2 templates (``.env``, ``compose.yml``,
+systemd unit), and either diffs the staged output against the live targets
+(``render`` action) or applies it (``apply`` action).
+
+Usage:
+    python -m deploy.render --profile pi render
+    python -m deploy.render --profile pi apply
+    python -m deploy.render --profile pi apply --host cfiet@192.168.1.2
+
+Design notes:
+    * Secrets are never templated: the profile declares ``secrets_env_path``
+      pointing at an untracked file (typically ``~/.config/are-they-hiring/
+      secrets.env``). Its contents are merged into the rendered ``.env`` in
+      the ``apply`` phase only, so rendered artefacts remain safe to commit
+      / diff.
+    * The renderer refuses to apply if the live ``compose.yml`` or systemd
+      unit is newer than the repo's last git commit (hand-edits guard).
+    * Remote deploys shell out to ``ssh``/``scp``; no paramiko.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from pydantic import BaseModel, ConfigDict, Field
+
+# Paths -----------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPLOY_DIR = REPO_ROOT / "deploy"
+TEMPLATES_DIR = DEPLOY_DIR / "templates"
+PROFILES_DIR = DEPLOY_DIR / "profiles"
+
+# Render outputs in this order. Each entry: (template_name, live_path_fn).
+# live_path_fn takes the HOME path and returns the live target path.
+RENDER_TARGETS: list[tuple[str, str]] = [
+    ("env.j2", ".config/are-they-hiring/.env"),
+    ("compose.prod.yml.j2", ".config/are-they-hiring/compose.yml"),
+    ("are-they-hiring-compose.service.j2", ".config/systemd/user/are-they-hiring-compose.service"),
+]
+
+
+# Profile schema --------------------------------------------------------
+
+
+class _StrictModel(BaseModel):
+    """Base model that rejects unknown keys so typos in profiles fail fast."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PostgresConfig(_StrictModel):
+    user: str = "arethey"
+    password: str = "CHANGE_ME_TO_A_STRONG_PASSWORD"
+    db: str = "arethey"
+    database_url: str = "postgresql+asyncpg://arethey:CHANGE_ME_TO_A_STRONG_PASSWORD@localhost:5432/arethey"
+
+
+class OllamaConfig(_StrictModel):
+    host: str = "http://ollama:11434"
+    model: str = "qwen2.5:1.5b"
+    keep_alive: str = "12h"
+    num_threads: int = 2
+    timeout_seconds: int = 300
+    cpus: float | None = None
+    cpu_shares: int | None = None
+
+
+class ClassifyConfig(_StrictModel):
+    concurrency: int = 2
+
+
+class ScrapeConfig(_StrictModel):
+    schedule: str = "06:00,12:00,18:00"
+    retry_max: int = 3
+
+
+class SystemdConfig(_StrictModel):
+    cpu_weight: int = Field(default=100, ge=1, le=10000)
+    io_weight: int = Field(default=100, ge=1, le=10000)
+    nice: int = Field(default=0, ge=-20, le=19)
+    timeout_start_sec: int = 300
+    timeout_stop_sec: int = 180
+
+
+class Profile(_StrictModel):
+    """Top-level profile schema. One instance per deployment target."""
+
+    host: str | None = None
+    tz: str = "UTC"
+    secrets_env_path: str | None = None
+    postgres: PostgresConfig = Field(default_factory=PostgresConfig)
+    ollama: OllamaConfig = Field(default_factory=OllamaConfig)
+    classify: ClassifyConfig = Field(default_factory=ClassifyConfig)
+    scrape: ScrapeConfig = Field(default_factory=ScrapeConfig)
+    systemd: SystemdConfig = Field(default_factory=SystemdConfig)
+
+
+# Loading and rendering -------------------------------------------------
+
+
+def load_profile(profile_name: str, profiles_dir: Path = PROFILES_DIR) -> Profile:
+    """Load and validate a profile by name (e.g. "pi")."""
+
+    path = profiles_dir / f"{profile_name}.yml"
+    if not path.exists():
+        raise FileNotFoundError(f"Profile not found: {path}")
+    data = yaml.safe_load(path.read_text()) or {}
+    return Profile.model_validate(data)
+
+
+def _jinja_env(templates_dir: Path = TEMPLATES_DIR) -> Environment:
+    return Environment(
+        loader=FileSystemLoader(templates_dir),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+        trim_blocks=False,
+        lstrip_blocks=False,
+    )
+
+
+def render_profile(
+    profile: Profile,
+    templates_dir: Path = TEMPLATES_DIR,
+) -> dict[str, str]:
+    """Render every template for ``profile``. Returns {template_name: text}."""
+
+    env = _jinja_env(templates_dir)
+    context = profile.model_dump()
+    return {tmpl: env.get_template(tmpl).render(**context) for tmpl, _ in RENDER_TARGETS}
+
+
+# .env parsing / secret merging ----------------------------------------
+
+
+def _parse_env_text(text: str) -> dict[str, str]:
+    """Parse a dotenv-style file into a key->value dict.
+
+    Ignores blank lines and comments. Values are not quoted/unquoted — they
+    are preserved verbatim. Only the first ``=`` is used as the separator.
+    """
+
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        out[key.strip()] = value
+    return out
+
+
+def merge_secrets(env_text: str, secrets_path: Path | None) -> str:
+    """Return ``env_text`` with any keys from ``secrets_path`` overriding.
+
+    If a secret key already exists in the rendered env, the secret value
+    replaces the rendered value in-place (preserves comments / ordering).
+    Secret keys not present get appended at the end under a banner.
+    """
+
+    if secrets_path is None or not secrets_path.exists():
+        return env_text
+
+    secrets = _parse_env_text(secrets_path.read_text())
+    if not secrets:
+        return env_text
+
+    lines = env_text.splitlines(keepends=True)
+    replaced: set[str] = set()
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key in secrets and key not in replaced:
+            trailing_newline = "\n" if raw.endswith("\n") else ""
+            lines[i] = f"{key}={secrets[key]}{trailing_newline}"
+            replaced.add(key)
+
+    out = "".join(lines)
+    extras = [k for k in secrets if k not in replaced]
+    if extras:
+        if not out.endswith("\n"):
+            out += "\n"
+        out += "\n# --- merged from secrets_env_path ---\n"
+        for k in extras:
+            out += f"{k}={secrets[k]}\n"
+    return out
+
+
+def orphan_keys(live_env_path: Path, rendered_env_text: str) -> list[str]:
+    """Return keys present in the live .env file but missing from rendered."""
+
+    if not live_env_path.exists():
+        return []
+    live_keys = set(_parse_env_text(live_env_path.read_text()))
+    rendered_keys = set(_parse_env_text(rendered_env_text))
+    return sorted(live_keys - rendered_keys)
+
+
+# Diffing & hand-edit guard --------------------------------------------
+
+
+def unified_diff(a_text: str, b_text: str, a_name: str, b_name: str) -> str:
+    diff = difflib.unified_diff(
+        a_text.splitlines(keepends=True),
+        b_text.splitlines(keepends=True),
+        fromfile=a_name,
+        tofile=b_name,
+    )
+    return "".join(diff)
+
+
+def _repo_last_commit_time(repo_path: Path = REPO_ROOT) -> float | None:
+    """Return the Unix mtime of the most recent git commit, or None on failure."""
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "log", "-1", "--format=%ct"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return float(result.stdout.strip())
+    except subprocess.CalledProcessError, FileNotFoundError, ValueError:
+        return None
+
+
+def hand_edit_check(live_path: Path, repo_last_commit_ts: float | None) -> bool:
+    """Return True if ``live_path`` was hand-edited after repo's last commit.
+
+    Returns False (no hand edit detected) if the file doesn't exist or the
+    commit timestamp is unavailable.
+    """
+
+    if repo_last_commit_ts is None or not live_path.exists():
+        return False
+    return live_path.stat().st_mtime > repo_last_commit_ts + 1
+
+
+# Apply -----------------------------------------------------------------
+
+
+@dataclass
+class RenderResult:
+    """Rendered artefacts for one profile."""
+
+    profile: Profile
+    rendered: dict[str, str]  # template_name -> rendered text
+
+    def env_text(self) -> str:
+        return self.rendered["env.j2"]
+
+    def compose_text(self) -> str:
+        return self.rendered["compose.prod.yml.j2"]
+
+    def service_text(self) -> str:
+        return self.rendered["are-they-hiring-compose.service.j2"]
+
+
+def _home() -> Path:
+    return Path(os.path.expanduser("~"))
+
+
+def _target_path(template_name: str, home: Path) -> Path:
+    relative = dict(RENDER_TARGETS)[template_name]
+    return home / relative
+
+
+def _write_staging(result: RenderResult, staging_dir: Path) -> dict[str, Path]:
+    """Write rendered files into ``staging_dir``. Returns {template: path}."""
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {}
+    filenames = {
+        "env.j2": "env",
+        "compose.prod.yml.j2": "compose.prod.yml",
+        "are-they-hiring-compose.service.j2": "are-they-hiring-compose.service",
+    }
+    for template_name, _ in RENDER_TARGETS:
+        path = staging_dir / filenames[template_name]
+        path.write_text(result.rendered[template_name])
+        paths[template_name] = path
+    return paths
+
+
+def cmd_render(profile: Profile, *, home: Path | None = None) -> int:
+    """Render the profile, diff vs live targets, print diffs. Does not apply."""
+
+    home = home or _home()
+    result = RenderResult(profile=profile, rendered=render_profile(profile))
+
+    print(f"Rendering profile -> staging diff vs {home}", file=sys.stderr)
+    any_diff = False
+    for template_name, _ in RENDER_TARGETS:
+        live = _target_path(template_name, home)
+        rendered = result.rendered[template_name]
+        live_text = live.read_text() if live.exists() else ""
+        diff = unified_diff(live_text, rendered, f"{live} (live)", f"{template_name} (rendered)")
+        if diff:
+            any_diff = True
+            print(diff)
+
+    orphans = orphan_keys(_target_path("env.j2", home), result.env_text())
+    if orphans:
+        print(
+            f"WARNING: live .env has keys not in the profile: {', '.join(orphans)}",
+            file=sys.stderr,
+        )
+
+    if not any_diff:
+        print("No differences between rendered output and live targets.", file=sys.stderr)
+    return 0
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def cmd_apply(
+    profile: Profile,
+    *,
+    host: str | None = None,
+    home: Path | None = None,
+    skip_restart: bool = False,
+) -> int:
+    """Render and install. Local by default; remote if ``host`` is set.
+
+    Refuses to apply if any live target is newer than the repo's last commit.
+    """
+
+    home = home or _home()
+    result = RenderResult(profile=profile, rendered=render_profile(profile))
+
+    # Hand-edit guard (local only; for remote the hand-edit check would need
+    # to run on the remote box — out of scope for v1).
+    if host is None:
+        repo_ts = _repo_last_commit_time()
+        for template_name, _ in RENDER_TARGETS:
+            live = _target_path(template_name, home)
+            if hand_edit_check(live, repo_ts):
+                live_text = live.read_text()
+                rendered = result.rendered[template_name]
+                diff = unified_diff(live_text, rendered, f"{live} (hand-edited)", f"{template_name} (rendered)")
+                print(
+                    f"ERROR: {live} is newer than the repo's last commit — refusing to overwrite.",
+                    file=sys.stderr,
+                )
+                print(diff, file=sys.stderr)
+                return 2
+
+    # Merge secrets into the rendered .env.
+    secrets_path = Path(os.path.expanduser(profile.secrets_env_path)) if profile.secrets_env_path else None
+    env_text = merge_secrets(result.env_text(), secrets_path)
+
+    # Orphan warning based on live .env.
+    orphans_path = _target_path("env.j2", home) if host is None else None
+    if orphans_path is not None:
+        orphans = orphan_keys(orphans_path, env_text)
+        if orphans:
+            print(
+                f"WARNING: live .env has keys not in the profile: {', '.join(orphans)}",
+                file=sys.stderr,
+            )
+
+    # Stage files in a temp dir (post secret merge).
+    with tempfile.TemporaryDirectory() as staging_raw:
+        staging = Path(staging_raw)
+        result.rendered["env.j2"] = env_text  # use merged version
+        staged_paths = _write_staging(result, staging)
+
+        if host is None:
+            _apply_local(staged_paths, home, skip_restart=skip_restart)
+        else:
+            _apply_remote(staged_paths, host, skip_restart=skip_restart)
+
+    return 0
+
+
+def _apply_local(staged_paths: dict[str, Path], home: Path, *, skip_restart: bool = False) -> None:
+    for template_name, rel in RENDER_TARGETS:
+        target = home / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(staged_paths[template_name], target)
+        print(f"wrote {target}", file=sys.stderr)
+
+    if skip_restart:
+        return
+    _run(["systemctl", "--user", "daemon-reload"])
+    _run(["systemctl", "--user", "restart", "are-they-hiring-compose.service"])
+
+
+def _apply_remote(staged_paths: dict[str, Path], host: str, *, skip_restart: bool = False) -> None:
+    # Use ~ in the remote path; ssh expands it in the remote shell.
+    for template_name, rel in RENDER_TARGETS:
+        remote_path = f"~/{rel}"
+        remote_dir = os.path.dirname(rel)
+        _run(["ssh", host, f"mkdir -p ~/{remote_dir}"])
+        _run(["scp", str(staged_paths[template_name]), f"{host}:{remote_path}"])
+        print(f"wrote {host}:{remote_path}", file=sys.stderr)
+
+    if skip_restart:
+        return
+    _run(
+        [
+            "ssh",
+            host,
+            "systemctl --user daemon-reload && systemctl --user restart are-they-hiring-compose.service",
+        ]
+    )
+
+
+# CLI --------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Profile-based deployment config renderer.")
+    parser.add_argument("--profile", required=True, help="Profile name (e.g. 'pi')")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    sub.add_parser("render", help="Render templates and diff against live targets.")
+
+    apply = sub.add_parser("apply", help="Render, copy to targets, restart service.")
+    apply.add_argument("--host", default=None, help="Remote host (e.g. user@1.2.3.4)")
+    apply.add_argument("--skip-restart", action="store_true", help="Skip daemon-reload + restart (useful in tests)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    profile = load_profile(args.profile)
+
+    if args.action == "render":
+        return cmd_render(profile)
+    if args.action == "apply":
+        return cmd_apply(profile, host=args.host, skip_restart=args.skip_restart)
+    parser.error(f"Unknown action: {args.action}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/templates/are-they-hiring-compose.service.j2
+++ b/deploy/templates/are-they-hiring-compose.service.j2
@@ -1,0 +1,26 @@
+[Unit]
+Description=Are They Hiring - All Services (podman-compose)
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=%h/.config/are-they-hiring
+ExecStart=/usr/bin/podman-compose -f compose.yml up -d
+ExecStop=/usr/bin/podman-compose -f compose.yml down
+TimeoutStartSec={{ systemd.timeout_start_sec }}
+TimeoutStopSec={{ systemd.timeout_stop_sec }}
+Restart=on-failure
+RestartSec=30
+{%- if systemd.cpu_weight != 100 %}
+CPUWeight={{ systemd.cpu_weight }}
+{%- endif %}
+{%- if systemd.io_weight != 100 %}
+IOWeight={{ systemd.io_weight }}
+{%- endif %}
+{%- if systemd.nice != 0 %}
+Nice={{ systemd.nice }}
+{%- endif %}
+
+[Install]
+WantedBy=default.target

--- a/deploy/templates/compose.prod.yml.j2
+++ b/deploy/templates/compose.prod.yml.j2
@@ -1,0 +1,41 @@
+version: "3.8"
+services:
+  db:
+    image: docker.io/postgres:16
+    env_file: .env
+    volumes:
+      - arethey-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U arethey"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  ollama:
+    image: localhost/are-they-hiring-ollama:latest
+    env_file: .env
+{%- if ollama.cpus is not none %}
+    cpus: ${OLLAMA_CPUS:-{{ ollama.cpus }}}
+{%- endif %}
+{%- if ollama.cpu_shares is not none %}
+    cpu_shares: {{ ollama.cpu_shares }}
+{%- endif %}
+
+  web:
+    image: localhost/are-they-hiring-web:latest
+    env_file: .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  scraper:
+    image: localhost/are-they-hiring-scraper:latest
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  arethey-db-data:

--- a/deploy/templates/env.j2
+++ b/deploy/templates/env.j2
@@ -1,0 +1,31 @@
+# Production .env for systemd deployment
+# Copy to ~/.config/are-they-hiring/.env and set real values
+
+# PostgreSQL (used by db, web, scraper containers)
+POSTGRES_USER={{ postgres.user }}
+POSTGRES_PASSWORD={{ postgres.password }}
+POSTGRES_DB={{ postgres.db }}
+DATABASE_URL={{ postgres.database_url }}
+
+# Ollama (used by scraper)
+# Use http://ollama:11434 if Ollama is a named service in compose; http://localhost:11434 for quadlet/pod
+OLLAMA_HOST={{ ollama.host }}
+OLLAMA_MODEL={{ ollama.model }}
+OLLAMA_TIMEOUT_SECONDS={{ ollama.timeout_seconds }}
+OLLAMA_KEEP_ALIVE={{ ollama.keep_alive }}
+# Constrained devices (e.g. Raspberry Pi): keep concurrency/threads low
+OLLAMA_NUM_THREADS={{ ollama.num_threads }}
+CLASSIFY_CONCURRENCY={{ classify.concurrency }}
+{%- if ollama.cpus is not none %}
+# Cap Ollama container CPU usage (compose only; leaves headroom for other services)
+OLLAMA_CPUS={{ ollama.cpus }}
+{%- else %}
+# OLLAMA_CPUS unset: no CPU cap on Ollama container
+{%- endif %}
+
+# Scraper schedule (UTC)
+SCRAPE_SCHEDULE={{ scrape.schedule }}
+SCRAPE_RETRY_MAX={{ scrape.retry_max }}
+
+# General
+TZ={{ tz }}

--- a/deploy/testdata/pi-expected/are-they-hiring-compose.service
+++ b/deploy/testdata/pi-expected/are-they-hiring-compose.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Are They Hiring - All Services (podman-compose)
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=%h/.config/are-they-hiring
+ExecStart=/usr/bin/podman-compose -f compose.yml up -d
+ExecStop=/usr/bin/podman-compose -f compose.yml down
+TimeoutStartSec=300
+TimeoutStopSec=180
+Restart=on-failure
+RestartSec=30
+CPUWeight=10
+IOWeight=10
+Nice=15
+
+[Install]
+WantedBy=default.target

--- a/deploy/testdata/pi-expected/compose.prod.yml
+++ b/deploy/testdata/pi-expected/compose.prod.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+services:
+  db:
+    image: docker.io/postgres:16
+    env_file: .env
+    volumes:
+      - arethey-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U arethey"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  ollama:
+    image: localhost/are-they-hiring-ollama:latest
+    env_file: .env
+    cpu_shares: 128
+
+  web:
+    image: localhost/are-they-hiring-web:latest
+    env_file: .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  scraper:
+    image: localhost/are-they-hiring-scraper:latest
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  arethey-db-data:

--- a/deploy/testdata/pi-expected/env
+++ b/deploy/testdata/pi-expected/env
@@ -1,0 +1,26 @@
+# Production .env for systemd deployment
+# Copy to ~/.config/are-they-hiring/.env and set real values
+
+# PostgreSQL (used by db, web, scraper containers)
+POSTGRES_USER=arethey
+POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD
+POSTGRES_DB=arethey
+DATABASE_URL=postgresql+asyncpg://arethey:CHANGE_ME_TO_A_STRONG_PASSWORD@localhost:5432/arethey
+
+# Ollama (used by scraper)
+# Use http://ollama:11434 if Ollama is a named service in compose; http://localhost:11434 for quadlet/pod
+OLLAMA_HOST=http://ollama:11434
+OLLAMA_MODEL=qwen2.5:1.5b
+OLLAMA_TIMEOUT_SECONDS=300
+OLLAMA_KEEP_ALIVE=12h
+# Constrained devices (e.g. Raspberry Pi): keep concurrency/threads low
+OLLAMA_NUM_THREADS=2
+CLASSIFY_CONCURRENCY=2
+# OLLAMA_CPUS unset: no CPU cap on Ollama container
+
+# Scraper schedule (UTC)
+SCRAPE_SCHEDULE=06:00,12:00,18:00
+SCRAPE_RETRY_MAX=3
+
+# General
+TZ=UTC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx>=0.28",
     "playwright>=1.49",
     "apscheduler>=3.10,<4",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_profile_schema.py
+++ b/tests/unit/test_profile_schema.py
@@ -1,0 +1,95 @@
+"""Pydantic validation edge cases for the deploy profile schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from deploy.render import (
+    OllamaConfig,
+    Profile,
+    SystemdConfig,
+    load_profile,
+)
+
+
+def test_defaults_are_sensible() -> None:
+    profile = Profile()
+    assert profile.tz == "UTC"
+    assert profile.ollama.model == "qwen2.5:1.5b"
+    assert profile.ollama.cpus is None
+    assert profile.ollama.cpu_shares is None
+    assert profile.systemd.cpu_weight == 100
+    assert profile.systemd.io_weight == 100
+    assert profile.systemd.nice == 0
+    assert profile.systemd.timeout_start_sec == 300
+    assert profile.systemd.timeout_stop_sec == 180
+
+
+def test_unknown_top_level_key_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Profile.model_validate({"bogus_key": "oops"})
+
+
+def test_unknown_nested_key_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Profile.model_validate({"ollama": {"typo_key": "oops"}})
+
+
+def test_nice_range_enforced() -> None:
+    with pytest.raises(ValidationError):
+        SystemdConfig(nice=100)
+    with pytest.raises(ValidationError):
+        SystemdConfig(nice=-100)
+
+
+def test_cpu_weight_range_enforced() -> None:
+    with pytest.raises(ValidationError):
+        SystemdConfig(cpu_weight=0)
+    with pytest.raises(ValidationError):
+        SystemdConfig(cpu_weight=100_000)
+
+
+def test_ollama_cpus_accepts_none_and_float() -> None:
+    assert OllamaConfig(cpus=None).cpus is None
+    assert OllamaConfig(cpus=3.0).cpus == 3.0
+
+
+def test_load_profile_raises_on_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_profile("does-not-exist", profiles_dir=tmp_path)
+
+
+def test_load_profile_roundtrip(tmp_path: Path) -> None:
+    profile_path = tmp_path / "foo.yml"
+    profile_path.write_text(
+        yaml.safe_dump(
+            {
+                "host": "user@1.2.3.4",
+                "tz": "Europe/London",
+                "ollama": {"model": "gemma3:270m", "cpus": 2.0, "cpu_shares": 64},
+                "systemd": {"cpu_weight": 10, "nice": 15},
+            }
+        )
+    )
+    profile = load_profile("foo", profiles_dir=tmp_path)
+    assert profile.host == "user@1.2.3.4"
+    assert profile.tz == "Europe/London"
+    assert profile.ollama.model == "gemma3:270m"
+    assert profile.ollama.cpus == 2.0
+    assert profile.ollama.cpu_shares == 64
+    assert profile.systemd.cpu_weight == 10
+    assert profile.systemd.nice == 15
+
+
+def test_secrets_env_path_preserved() -> None:
+    profile = Profile.model_validate({"secrets_env_path": "~/secrets.env"})
+    assert profile.secrets_env_path == "~/secrets.env"
+
+
+def test_host_optional() -> None:
+    assert Profile().host is None
+    assert Profile(host="user@host").host == "user@host"

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -1,0 +1,206 @@
+"""Golden-output tests for the deployment renderer.
+
+These guard against template drift. When a template or profile changes, the
+golden files under ``deploy/testdata/pi-expected/`` must be updated in the
+same commit so the diff is reviewable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deploy.render import (
+    OllamaConfig,
+    Profile,
+    SystemdConfig,
+    hand_edit_check,
+    load_profile,
+    merge_secrets,
+    orphan_keys,
+    render_profile,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOLDEN_DIR = REPO_ROOT / "deploy" / "testdata" / "pi-expected"
+
+
+TEMPLATE_TO_GOLDEN = {
+    "env.j2": "env",
+    "compose.prod.yml.j2": "compose.prod.yml",
+    "are-they-hiring-compose.service.j2": "are-they-hiring-compose.service",
+}
+
+
+@pytest.mark.parametrize("template_name,golden_name", list(TEMPLATE_TO_GOLDEN.items()))
+def test_pi_profile_matches_golden(template_name: str, golden_name: str) -> None:
+    profile = load_profile("pi")
+    rendered = render_profile(profile)[template_name]
+    expected = (GOLDEN_DIR / golden_name).read_text()
+    assert rendered == expected, (
+        f"rendered {template_name} differs from {golden_name}; "
+        "if the change is intentional, regenerate the golden file."
+    )
+
+
+def test_baseline_profile_reproduces_legacy_env_example() -> None:
+    """A default-ish profile must render identically to today's .env.example.
+
+    Existing Pi deployments expect the rendered output to match what they
+    already have on disk. If this breaks, we've introduced a drift that
+    would cause an unexpected systemctl restart on the next deploy.
+    """
+
+    profile = Profile(ollama=OllamaConfig(cpus=3.0, cpu_shares=None))
+    rendered = render_profile(profile)["env.j2"]
+    legacy = (REPO_ROOT / "podman" / "systemd" / ".env.example").read_text()
+    assert rendered == legacy
+
+
+def test_baseline_profile_reproduces_legacy_compose() -> None:
+    profile = Profile(ollama=OllamaConfig(cpus=3.0, cpu_shares=None))
+    rendered = render_profile(profile)["compose.prod.yml.j2"]
+    legacy = (REPO_ROOT / "podman-compose.prod.yml").read_text()
+    assert rendered == legacy
+
+
+def test_baseline_profile_reproduces_legacy_systemd_unit() -> None:
+    profile = Profile(ollama=OllamaConfig(cpus=3.0, cpu_shares=None))
+    rendered = render_profile(profile)["are-they-hiring-compose.service.j2"]
+    legacy = (REPO_ROOT / "podman" / "systemd" / "are-they-hiring-compose.service").read_text()
+    assert rendered == legacy
+
+
+def test_cpu_priority_knobs_emit_systemd_directives() -> None:
+    profile = Profile(systemd=SystemdConfig(cpu_weight=10, io_weight=10, nice=15))
+    unit = render_profile(profile)["are-they-hiring-compose.service.j2"]
+    assert "CPUWeight=10" in unit
+    assert "IOWeight=10" in unit
+    assert "Nice=15" in unit
+
+
+def test_default_systemd_omits_cpu_priority_directives() -> None:
+    """Defaults preserve today's unit file shape (no CPUWeight/IOWeight/Nice)."""
+
+    profile = Profile()
+    unit = render_profile(profile)["are-they-hiring-compose.service.j2"]
+    assert "CPUWeight" not in unit
+    assert "IOWeight" not in unit
+    assert "Nice=" not in unit
+
+
+def test_compose_drops_ollama_cpu_cap_when_null() -> None:
+    profile = Profile(ollama=OllamaConfig(cpus=None))
+    compose = render_profile(profile)["compose.prod.yml.j2"]
+    assert "cpus:" not in compose
+
+
+def test_compose_includes_cpu_shares_when_set() -> None:
+    profile = Profile(ollama=OllamaConfig(cpus=None, cpu_shares=128))
+    compose = render_profile(profile)["compose.prod.yml.j2"]
+    assert "cpu_shares: 128" in compose
+
+
+def test_merge_secrets_replaces_in_place(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("POSTGRES_PASSWORD=realpass\n")
+    rendered = "POSTGRES_USER=arethey\nPOSTGRES_PASSWORD=PLACEHOLDER\n"
+    merged = merge_secrets(rendered, secrets)
+    assert "POSTGRES_PASSWORD=realpass" in merged
+    assert "PLACEHOLDER" not in merged
+    # Unrelated keys preserved.
+    assert "POSTGRES_USER=arethey" in merged
+
+
+def test_merge_secrets_appends_new_keys(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("EXTRA_KEY=42\n")
+    rendered = "POSTGRES_USER=arethey\n"
+    merged = merge_secrets(rendered, secrets)
+    assert "EXTRA_KEY=42" in merged
+    assert "merged from secrets_env_path" in merged
+
+
+def test_merge_secrets_no_file(tmp_path: Path) -> None:
+    rendered = "POSTGRES_USER=arethey\n"
+    assert merge_secrets(rendered, tmp_path / "missing.env") == rendered
+
+
+def test_merge_secrets_none_path() -> None:
+    rendered = "POSTGRES_USER=arethey\n"
+    assert merge_secrets(rendered, None) == rendered
+
+
+def test_orphan_keys_warns_on_drift(tmp_path: Path) -> None:
+    live = tmp_path / ".env"
+    live.write_text("POSTGRES_USER=arethey\nLEGACY_KEY=1\n")
+    rendered = "POSTGRES_USER=arethey\n"
+    assert orphan_keys(live, rendered) == ["LEGACY_KEY"]
+
+
+def test_orphan_keys_empty_when_live_missing(tmp_path: Path) -> None:
+    assert orphan_keys(tmp_path / "missing", "POSTGRES_USER=arethey\n") == []
+
+
+def test_hand_edit_check_flags_newer_file(tmp_path: Path) -> None:
+    live = tmp_path / "compose.yml"
+    live.write_text("...")
+    # Simulate: commit was 1000s ago, file mtime set to now.
+    import time
+
+    now = time.time()
+    commit_ts = now - 1000
+    # mtime default is now, which is commit_ts + 1000 > commit_ts + 1.
+    assert hand_edit_check(live, commit_ts) is True
+
+
+def test_hand_edit_check_ignores_missing_file(tmp_path: Path) -> None:
+    assert hand_edit_check(tmp_path / "missing", 0.0) is False
+
+
+def test_hand_edit_check_ignores_missing_commit_ts(tmp_path: Path) -> None:
+    live = tmp_path / "x"
+    live.write_text("a")
+    assert hand_edit_check(live, None) is False
+
+
+def test_cmd_apply_writes_all_three_targets(tmp_path: Path) -> None:
+    """End-to-end: cmd_apply(skip_restart=True) creates every target file."""
+
+    from deploy.render import cmd_apply, load_profile
+
+    profile = load_profile("pi")
+    profile.secrets_env_path = None  # don't touch the real secrets file
+
+    rc = cmd_apply(profile, host=None, home=tmp_path, skip_restart=True)
+    assert rc == 0
+    assert (tmp_path / ".config/are-they-hiring/.env").exists()
+    assert (tmp_path / ".config/are-they-hiring/compose.yml").exists()
+    assert (tmp_path / ".config/systemd/user/are-they-hiring-compose.service").exists()
+
+
+def test_cmd_apply_merges_secrets(tmp_path: Path) -> None:
+    """cmd_apply substitutes values from secrets_env_path in the rendered .env.
+
+    Users put both POSTGRES_PASSWORD and the matching DATABASE_URL in their
+    local secrets.env (or replace the DATABASE_URL upstream). The renderer
+    does a per-line key= override; it does not rewrite values embedded in
+    other values.
+    """
+
+    from deploy.render import cmd_apply, load_profile
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text(
+        "POSTGRES_PASSWORD=hunter2\nDATABASE_URL=postgresql+asyncpg://arethey:hunter2@localhost:5432/arethey\n"
+    )
+
+    profile = load_profile("pi")
+    profile.secrets_env_path = str(secrets)
+
+    cmd_apply(profile, host=None, home=tmp_path, skip_restart=True)
+    env_text = (tmp_path / ".config/are-they-hiring/.env").read_text()
+    assert "POSTGRES_PASSWORD=hunter2" in env_text
+    assert "DATABASE_URL=postgresql+asyncpg://arethey:hunter2@" in env_text
+    assert "CHANGE_ME_TO_A_STRONG_PASSWORD" not in env_text

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -116,6 +117,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.34" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },


### PR DESCRIPTION
Closes #37.

## Summary

- Introduces `deploy/` with a pydantic-validated profile (`deploy/profiles/pi.yml`), three Jinja2 templates (`.env`, `compose.yml`, systemd unit), and `deploy/render.py` exposing `render` / `apply` actions.
- Wires up `make deploy PROFILE=pi` (local) and `make deploy PROFILE=pi HOST=user@host` (remote, over `ssh`/`scp`). `make deploy-render PROFILE=pi` previews the diff without applying.
- Secrets (DB password, matching `DATABASE_URL`) stay in a local `secrets.env` outside the repo; the renderer merges them into the rendered `.env` at apply time only.
- Keeps `make install-compose` working (with a deprecation notice) so in-flight Pi deployments can migrate at their own pace.

## CPU prioritization tweak (first use case)

The "deprioritize Ollama vs the OS" change discussed in chat ships as a profile-only diff:

`deploy/profiles/pi.yml`:
- `ollama.cpus: null` (drop the 3.0 cap)
- `ollama.cpu_shares: 128`
- `systemd.cpu_weight: 10`, `io_weight: 10`, `nice: 15`

The diff between the current Pi files and the new rendered output is exactly these additions — nothing else moved:

<details>
<summary>`.env.example` → rendered env</summary>

\`\`\`diff
-# Cap Ollama container CPU usage (compose only; leaves headroom for other services)
-OLLAMA_CPUS=3.0
+# OLLAMA_CPUS unset: no CPU cap on Ollama container
\`\`\`
</details>

<details>
<summary>`podman-compose.prod.yml` → rendered compose</summary>

\`\`\`diff
   ollama:
     image: localhost/are-they-hiring-ollama:latest
     env_file: .env
-    cpus: \${OLLAMA_CPUS:-3.0}
+    cpu_shares: 128
\`\`\`
</details>

<details>
<summary>`are-they-hiring-compose.service` → rendered unit</summary>

\`\`\`diff
 Restart=on-failure
 RestartSec=30
+CPUWeight=10
+IOWeight=10
+Nice=15
\`\`\`
</details>

## Design decisions

- **Schema:** pydantic with `extra="forbid"`; unknown/typo'd keys in `pi.yml` fail at load time instead of silently doing nothing.
- **Backwards compat:** a minimal default-valued profile (`cpus=3.0`, `cpu_shares=None`, systemd defaults) renders byte-for-byte identical output to today's `.env.example`, `podman-compose.prod.yml`, and `are-they-hiring-compose.service`. Covered by `tests/unit/test_render.py::test_baseline_profile_reproduces_*` so future template changes can't silently drift existing deployments.
- **Golden tests:** `deploy/testdata/pi-expected/` pins what `pi.yml` currently renders, parametrised over the three templates. Regenerate by re-rendering whenever a template or profile intentionally changes.
- **Secrets:** file-based `secrets.env` outside git is v1. The renderer only substitutes whole-line `KEY=...` entries; users need both `POSTGRES_PASSWORD=` and the matching `DATABASE_URL=` in their secrets file (documented inline in `pi.yml`). Upgrade path: sops/age later.
- **Remote transport:** `scp` + `ssh` via `subprocess` — no paramiko dependency. The `--host` flag on `apply` drives the remote path.
- **Hand-edit guard:** `apply` compares each live file's mtime to the repo's last commit timestamp and refuses to overwrite if someone hand-edited the live unit or compose file (prints their diff so a human can reconcile).

## Test plan

- [x] `make test` — unit + integration (108 tests, all green, incl. 31 new under `tests/unit/`).
- [x] `make lint` + `make lint-fix` — ruff clean across `src/ tests/ deploy/`.
- [x] `uv run pre-commit run --all-files` — all hooks pass.
- [x] `uv run python -m deploy.render --profile pi render` — renders and prints diff vs `$HOME/.config/...`.
- [x] `cmd_apply` smoke-tested against a tmpdir HOME (file layout matches `~/.config/are-they-hiring/{.env,compose.yml}` and `~/.config/systemd/user/are-they-hiring-compose.service`).
- [ ] Deploy to the Pi via `make deploy PROFILE=pi HOST=cfiet@192.168.1.2` (user-side verification — the expectation is the diff vs today's live files is just the three CPU-prio lines above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)