### PR TITLE
experiment: embedding classifier prototype (refs #36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 .pytest_cache/
 .mypy_cache/
 .superpowers/
+
+# Embedding experiment caches (#36) — regeneratable from /tmp/roles-to-label.csv
+scripts/cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dev = [
     "aiosqlite>=0.20",
     "httpx>=0.28",
     "ruff>=0.15",
+    "scikit-learn>=1.8.0",
+    "numpy>=2.4.4",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/embed_classify_experiment.py
+++ b/scripts/embed_classify_experiment.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Embedding + tiny classifier head experiment (refs issue #36).
+
+Loads the hand-labelled ground-truth CSV, embeds every title via Ollama, trains
+LogisticRegression and LinearSVC heads, and reports accuracy / precision / recall
+for each (embedding_model, classifier_head) pair against an 80/20 stratified split.
+
+The baseline to beat (qwen2.5:1.5b, LLM few-shot classifier, same 1381 titles):
+    accuracy=97.8%  precision=69.8%  recall=72.5%
+
+This script caches embeddings to disk keyed on (model, title) so reruns are fast,
+and saves the fitted classifiers as pickles alongside the cache.
+
+Usage:
+    uv run python scripts/embed_classify_experiment.py \\
+        --input /tmp/roles-to-label.csv \\
+        --ollama-host http://pop-os.home.lan:11434 \\
+        --models all-minilm nomic-embed-text mxbai-embed-large
+
+Ollama's /api/embed endpoint is used (Ollama >= 0.1.45). One request per title,
+served sequentially — pop-os GPU handles ~100 titles/s for the small models.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import hashlib
+import json
+import pickle
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import confusion_matrix
+from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.preprocessing import normalize
+from sklearn.svm import LinearSVC
+
+DEFAULT_MODELS = ["all-minilm", "nomic-embed-text", "mxbai-embed-large"]
+DEFAULT_OLLAMA_HOST = "http://pop-os.home.lan:11434"
+DEFAULT_INPUT = "/tmp/roles-to-label.csv"
+DEFAULT_CACHE_DIR = Path("scripts/cache")
+DEFAULT_CONCURRENCY = 8
+DEFAULT_TIMEOUT = 60.0
+RANDOM_STATE = 42  # stable split across reruns
+
+# nomic-embed-text is trained with task-prefixed inputs. "classification:" is the
+# supported prefix for supervised-classification use (see Ollama nomic docs).
+MODEL_INPUT_PREFIX = {
+    "nomic-embed-text": "classification: ",
+}
+
+
+@dataclass
+class EvalResult:
+    model: str
+    head: str
+    accuracy: float
+    precision: float
+    recall: float
+    tp: int
+    fp: int
+    tn: int
+    fn: int
+    dim: int
+    train_n: int
+    test_n: int
+
+    def format_row(self) -> str:
+        return (
+            f"| {self.model:<18} | {self.head:<20} | "
+            f"{self.accuracy * 100:6.2f}% | {self.precision * 100:6.2f}% | "
+            f"{self.recall * 100:6.2f}% | {self.tp:>3} | {self.fp:>3} | "
+            f"{self.tn:>4} | {self.fn:>3} | {self.dim:>4} |"
+        )
+
+
+def load_labels(path: Path) -> tuple[list[str], np.ndarray]:
+    titles: list[str] = []
+    labels: list[int] = []
+    seen: set[str] = set()
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        required = {"title", "your_label"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise SystemExit(f"CSV is missing required columns: {missing}")
+        for row in reader:
+            title = (row.get("title") or "").strip()
+            label = (row.get("your_label") or "").strip().lower()
+            if not title or label not in {"yes", "no"}:
+                continue
+            if title in seen:
+                continue
+            seen.add(title)
+            titles.append(title)
+            labels.append(1 if label == "yes" else 0)
+    y = np.asarray(labels, dtype=np.int64)
+    return titles, y
+
+
+def cache_path_for(cache_dir: Path, model: str) -> Path:
+    safe = model.replace("/", "_").replace(":", "_")
+    prefix = MODEL_INPUT_PREFIX.get(model, "")
+    # Keep the filename deterministic; embed the prefix state in a short suffix
+    # so a prefix change invalidates the cache automatically.
+    suffix = ""
+    if prefix:
+        suffix = "-p" + hashlib.sha1(prefix.encode()).hexdigest()[:6]
+    return cache_dir / f"embeddings-{safe}{suffix}.npz"
+
+
+def load_embedding_cache(path: Path) -> dict[str, np.ndarray]:
+    if not path.exists():
+        return {}
+    with np.load(path, allow_pickle=False) as data:
+        titles = data["titles"]
+        vectors = data["vectors"]
+    return {str(t): vectors[i] for i, t in enumerate(titles)}
+
+
+def save_embedding_cache(path: Path, cache: dict[str, np.ndarray]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    titles = np.array(list(cache.keys()), dtype=str)
+    vectors = np.stack(list(cache.values())).astype(np.float32)
+    np.savez(path, titles=titles, vectors=vectors)
+
+
+async def _embed_one(
+    client: httpx.AsyncClient,
+    host: str,
+    model: str,
+    title: str,
+) -> tuple[str, np.ndarray]:
+    prefix = MODEL_INPUT_PREFIX.get(model, "")
+    response = await client.post(
+        f"{host}/api/embed",
+        json={"model": model, "input": f"{prefix}{title}"},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    # /api/embed returns {"embeddings": [[...]], ...}; /api/embeddings returns
+    # {"embedding": [...]}. Support both for forward/backward compatibility.
+    if "embeddings" in payload:
+        vector = np.asarray(payload["embeddings"][0], dtype=np.float32)
+    elif "embedding" in payload:
+        vector = np.asarray(payload["embedding"], dtype=np.float32)
+    else:
+        raise RuntimeError(f"Unexpected embed response for model={model}: {list(payload)[:5]}")
+    return title, vector
+
+
+async def embed_titles(
+    titles: list[str],
+    model: str,
+    host: str,
+    cache: dict[str, np.ndarray],
+    concurrency: int,
+    timeout: float,
+) -> dict[str, np.ndarray]:
+    missing = [t for t in titles if t not in cache]
+    if not missing:
+        return cache
+
+    print(f"    embedding {len(missing)}/{len(titles)} titles (cache hit: {len(titles) - len(missing)})")
+    semaphore = asyncio.Semaphore(concurrency)
+    completed = 0
+    total = len(missing)
+    start = time.time()
+
+    async def _wrap(client: httpx.AsyncClient, title: str) -> None:
+        nonlocal completed
+        async with semaphore:
+            try:
+                t, vec = await _embed_one(client, host, model, title)
+            except Exception as exc:
+                print(f"      error embedding {title!r}: {exc}")
+                raise
+        cache[t] = vec
+        completed += 1
+        if completed % 100 == 0 or completed == total:
+            elapsed = time.time() - start
+            rate = completed / elapsed if elapsed > 0 else 0
+            print(f"      progress: {completed}/{total} ({rate:.1f} titles/s)")
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        await asyncio.gather(*[_wrap(client, t) for t in missing])
+
+    return cache
+
+
+def _confusion_parts(y_true: np.ndarray, y_pred: np.ndarray) -> tuple[int, int, int, int]:
+    # confusion_matrix labels order: [0, 1] -> rows truth, cols pred
+    cm = confusion_matrix(y_true, y_pred, labels=[0, 1])
+    tn, fp, fn, tp = cm.ravel()
+    return int(tp), int(fp), int(tn), int(fn)
+
+
+def evaluate_head(
+    model: str,
+    head_label: str,
+    X_train: np.ndarray,
+    X_test: np.ndarray,
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+    head,
+    out_pickle: Path,
+) -> EvalResult:
+    head.fit(X_train, y_train)
+    y_pred = head.predict(X_test)
+    tp, fp, tn, fn = _confusion_parts(y_test, y_pred)
+    accuracy = (tp + tn) / max(tp + fp + tn + fn, 1)
+    precision = tp / max(tp + fp, 1)
+    recall = tp / max(tp + fn, 1)
+    out_pickle.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_pickle, "wb") as f:
+        pickle.dump(head, f)
+    return EvalResult(
+        model=model,
+        head=head_label,
+        accuracy=accuracy,
+        precision=precision,
+        recall=recall,
+        tp=tp,
+        fp=fp,
+        tn=tn,
+        fn=fn,
+        dim=int(X_train.shape[1]),
+        train_n=int(X_train.shape[0]),
+        test_n=int(X_test.shape[0]),
+    )
+
+
+def ensure_model_available(host: str, model: str, timeout: float) -> None:
+    """Best-effort pull: if the embedding model isn't loaded on the Ollama host,
+    ask Ollama to pull it. Pulls are idempotent. Blocks until completion."""
+    try:
+        resp = httpx.get(f"{host}/api/tags", timeout=10)
+        resp.raise_for_status()
+        names = {m["name"] for m in resp.json().get("models", [])}
+    except Exception as exc:
+        print(f"    warning: could not list models on {host}: {exc}")
+        names = set()
+    needed = model if ":" in model else f"{model}:latest"
+    if model in names or needed in names:
+        return
+    print(f"    pulling {model} on {host} (one-time)...")
+    with httpx.Client(timeout=timeout) as client:
+        r = client.post(f"{host}/api/pull", json={"name": model, "stream": False})
+        r.raise_for_status()
+
+
+def _safe_model_slug(model: str) -> str:
+    return model.replace("/", "_").replace(":", "_")
+
+
+def _cv_metrics(X: np.ndarray, y: np.ndarray, make_head) -> tuple[int, int, int, int]:
+    """Aggregate confusion parts across stratified 5-fold CV predictions.
+
+    We union the out-of-fold predictions and compute a single confusion matrix.
+    This is the standard small-dataset approach to stabilise precision/recall when
+    positives are rare (51/1381 here)."""
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_STATE)
+    tp = fp = tn = fn = 0
+    for tr_idx, te_idx in kf.split(X, y):
+        head = make_head()
+        head.fit(X[tr_idx], y[tr_idx])
+        y_pred = head.predict(X[te_idx])
+        a, b, c, d = _confusion_parts(y[te_idx], y_pred)
+        tp += a
+        fp += b
+        tn += c
+        fn += d
+    return tp, fp, tn, fn
+
+
+def _cv_threshold_sweep(X: np.ndarray, y: np.ndarray) -> list[tuple[float, int, int, int, int]]:
+    """Aggregate out-of-fold LR probabilities across 5-fold CV, then sweep the
+    decision threshold. Returns [(threshold, tp, fp, tn, fn), ...]."""
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_STATE)
+    proba = np.zeros(len(y), dtype=np.float64)
+    for tr_idx, te_idx in kf.split(X, y):
+        head = LogisticRegression(C=1.0, max_iter=5000, solver="liblinear", random_state=RANDOM_STATE)
+        head.fit(X[tr_idx], y[tr_idx])
+        proba[te_idx] = head.predict_proba(X[te_idx])[:, 1]
+    rows = []
+    for thr in [0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50]:
+        y_pred = (proba >= thr).astype(np.int64)
+        tp, fp, tn, fn = _confusion_parts(y, y_pred)
+        rows.append((thr, tp, fp, tn, fn))
+    return rows
+
+
+def _print_result(tag: str, res: EvalResult) -> None:
+    print(
+        f"    {tag} "
+        f"acc={res.accuracy * 100:5.2f}% "
+        f"prec={res.precision * 100:5.2f}% "
+        f"rec={res.recall * 100:5.2f}% "
+        f"(tp={res.tp} fp={res.fp} fn={res.fn})"
+    )
+
+
+def _eval_from_counts(
+    model: str, head_label: str, tp: int, fp: int, tn: int, fn: int, dim: int, train_n: int, test_n: int
+) -> EvalResult:
+    accuracy = (tp + tn) / max(tp + fp + tn + fn, 1)
+    precision = tp / max(tp + fp, 1)
+    recall = tp / max(tp + fn, 1)
+    return EvalResult(
+        model=model,
+        head=head_label,
+        accuracy=accuracy,
+        precision=precision,
+        recall=recall,
+        tp=tp,
+        fp=fp,
+        tn=tn,
+        fn=fn,
+        dim=dim,
+        train_n=train_n,
+        test_n=test_n,
+    )
+
+
+async def run_experiment(
+    csv_path: Path,
+    ollama_host: str,
+    models: list[str],
+    cache_dir: Path,
+    concurrency: int,
+    timeout: float,
+    l2_normalize: bool,
+    cv: bool,
+) -> list[EvalResult]:
+    titles, y = load_labels(csv_path)
+    print(f"Loaded {len(titles)} labelled titles ({int(y.sum())} yes / {len(y) - int(y.sum())} no)")
+
+    train_titles, test_titles, y_train, y_test = train_test_split(
+        titles,
+        y,
+        test_size=0.2,
+        random_state=RANDOM_STATE,
+        stratify=y,
+    )
+    print(
+        f"Split: train={len(train_titles)} (yes={int(y_train.sum())}) test={len(test_titles)} (yes={int(y_test.sum())})"
+    )
+    if l2_normalize:
+        print("Embeddings will be L2-normalized before fitting.")
+    if cv:
+        print("Also running stratified 5-fold CV for stabilised precision/recall.")
+
+    def make_lr():
+        return LogisticRegression(
+            C=1.0,
+            class_weight="balanced",
+            max_iter=5000,
+            solver="liblinear",
+            random_state=RANDOM_STATE,
+        )
+
+    def make_svm():
+        return LinearSVC(
+            C=1.0,
+            class_weight="balanced",
+            max_iter=5000,
+            random_state=RANDOM_STATE,
+        )
+
+    def make_lr_nobal():
+        return LogisticRegression(
+            C=1.0,
+            max_iter=5000,
+            solver="liblinear",
+            random_state=RANDOM_STATE,
+        )
+
+    def make_svm_nobal():
+        return LinearSVC(
+            C=1.0,
+            max_iter=5000,
+            random_state=RANDOM_STATE,
+        )
+
+    results: list[EvalResult] = []
+    for model in models:
+        print(f"\n=== {model} ===")
+        ensure_model_available(ollama_host, model, timeout=600.0)
+        cache_path = cache_path_for(cache_dir, model)
+        cache = load_embedding_cache(cache_path)
+        cache = await embed_titles(titles, model, ollama_host, cache, concurrency=concurrency, timeout=timeout)
+        save_embedding_cache(cache_path, cache)
+
+        X_all = np.stack([cache[t] for t in titles]).astype(np.float32)
+        X_train = np.stack([cache[t] for t in train_titles]).astype(np.float32)
+        X_test = np.stack([cache[t] for t in test_titles]).astype(np.float32)
+        if l2_normalize:
+            X_all = normalize(X_all)
+            X_train = normalize(X_train)
+            X_test = normalize(X_test)
+
+        slug = _safe_model_slug(model)
+        lr_pickle = cache_dir / f"classifier-{slug}-lr.pkl"
+        res_lr = evaluate_head(model, "LogisticRegression", X_train, X_test, y_train, y_test, make_lr(), lr_pickle)
+        _print_result("LogReg ", res_lr)
+        results.append(res_lr)
+
+        svm_pickle = cache_dir / f"classifier-{slug}-svm.pkl"
+        res_svm = evaluate_head(model, "LinearSVC", X_train, X_test, y_train, y_test, make_svm(), svm_pickle)
+        _print_result("SVM    ", res_svm)
+        results.append(res_svm)
+
+        # Also try the unbalanced heads — they trade recall for precision, which is
+        # what the baseline actually optimises for.
+        lr_nb_pickle = cache_dir / f"classifier-{slug}-lr-nobal.pkl"
+        res_lr_nb = evaluate_head(
+            model,
+            "LogisticRegression (no class_weight)",
+            X_train,
+            X_test,
+            y_train,
+            y_test,
+            make_lr_nobal(),
+            lr_nb_pickle,
+        )
+        _print_result("LR-nb  ", res_lr_nb)
+        results.append(res_lr_nb)
+
+        svm_nb_pickle = cache_dir / f"classifier-{slug}-svm-nobal.pkl"
+        res_svm_nb = evaluate_head(
+            model,
+            "LinearSVC (no class_weight)",
+            X_train,
+            X_test,
+            y_train,
+            y_test,
+            make_svm_nobal(),
+            svm_nb_pickle,
+        )
+        _print_result("SVM-nb ", res_svm_nb)
+        results.append(res_svm_nb)
+
+        if cv:
+            for label, factory in [
+                ("LogisticRegression (5-fold CV)", make_lr),
+                ("LinearSVC (5-fold CV)", make_svm),
+                ("LogisticRegression no-balance (5-fold CV)", make_lr_nobal),
+                ("LinearSVC no-balance (5-fold CV)", make_svm_nobal),
+            ]:
+                tp, fp, tn, fn = _cv_metrics(X_all, y, factory)
+                res = _eval_from_counts(
+                    model,
+                    label,
+                    tp,
+                    fp,
+                    tn,
+                    fn,
+                    dim=int(X_all.shape[1]),
+                    train_n=int(len(y) * 0.8),
+                    test_n=int(len(y)),
+                )
+                _print_result(f"CV[{label[:30]:<30}]", res)
+                results.append(res)
+
+            # Threshold sweep on no-balance LR probabilities — shows the full
+            # precision/recall frontier for this embedding, rather than just the
+            # operating point sklearn's default decision rule picks.
+            print("    threshold sweep (LR no-balance, 5-fold CV):")
+            print(f"      {'thr':>5}  {'acc':>7}  {'prec':>7}  {'recall':>7}  {'tp':>3}  {'fp':>3}  {'fn':>3}")
+            for thr, tp, fp, tn, fn in _cv_threshold_sweep(X_all, y):
+                acc = (tp + tn) / max(tp + fp + tn + fn, 1)
+                prec = tp / max(tp + fp, 1)
+                rec = tp / max(tp + fn, 1)
+                line = (
+                    f"      {thr:>5.2f}  {acc * 100:6.2f}%  "
+                    f"{prec * 100:6.2f}%  {rec * 100:6.2f}%  "
+                    f"{tp:>3}  {fp:>3}  {fn:>3}"
+                )
+                print(line)
+                results.append(
+                    _eval_from_counts(
+                        model,
+                        f"LR-thr={thr:.2f} (5-fold CV)",
+                        tp,
+                        fp,
+                        tn,
+                        fn,
+                        dim=int(X_all.shape[1]),
+                        train_n=int(len(y) * 0.8),
+                        test_n=int(len(y)),
+                    )
+                )
+
+    return results
+
+
+def write_results_json(results: list[EvalResult], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = [
+        {
+            "model": r.model,
+            "head": r.head,
+            "accuracy": r.accuracy,
+            "precision": r.precision,
+            "recall": r.recall,
+            "tp": r.tp,
+            "fp": r.fp,
+            "tn": r.tn,
+            "fn": r.fn,
+            "dim": r.dim,
+            "train_n": r.train_n,
+            "test_n": r.test_n,
+        }
+        for r in results
+    ]
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def print_summary(results: list[EvalResult]) -> None:
+    print("\n" + "=" * 110)
+    print("SUMMARY (80/20 stratified hold-out, seed=42)")
+    print("=" * 110)
+    header = (
+        f"| {'model':<18} | {'head':<20} | "
+        f"{'acc':>7} | {'prec':>7} | {'recall':>7} | "
+        f"{'tp':>3} | {'fp':>3} | {'tn':>4} | {'fn':>3} | {'dim':>4} |"
+    )
+    sep = "|" + "|".join(["-" * (len(s) + 2) for s in header.strip("|").split("|")]) + "|"
+    print(header)
+    print(sep)
+    for r in results:
+        print(r.format_row())
+    print(
+        "\nBaseline to beat (qwen2.5:1.5b LLM few-shot, same 1381 labels, full set):\n"
+        "  accuracy=97.8%  precision=69.8%  recall=72.5%"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=Path(DEFAULT_INPUT))
+    parser.add_argument("--ollama-host", default=DEFAULT_OLLAMA_HOST)
+    parser.add_argument("--models", nargs="+", default=DEFAULT_MODELS)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument(
+        "--l2-normalize",
+        action="store_true",
+        help="L2-normalize embeddings before fitting (standard for cosine-style heads).",
+    )
+    parser.add_argument(
+        "--cv",
+        action="store_true",
+        help="Also report stratified 5-fold CV metrics (more stable than the single 80/20 split).",
+    )
+    parser.add_argument(
+        "--results-json",
+        type=Path,
+        default=Path("scripts/cache/results.json"),
+        help="Where to write the raw JSON results",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        print(f"input CSV not found: {args.input}", file=sys.stderr)
+        return 2
+
+    results = asyncio.run(
+        run_experiment(
+            csv_path=args.input,
+            ollama_host=args.ollama_host,
+            models=args.models,
+            cache_dir=args.cache_dir,
+            concurrency=args.concurrency,
+            timeout=args.timeout,
+            l2_normalize=args.l2_normalize,
+            cv=args.cv,
+        )
+    )
+    print_summary(results)
+    write_results_json(results, args.results_json)
+    print(f"\nResults JSON written to {args.results_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/embed_classify_results.md
+++ b/scripts/embed_classify_results.md
@@ -1,0 +1,172 @@
+# Embedding + classifier-head prototype — results (refs #36)
+
+Prototype for issue [#36](https://github.com/maciej-makowski/are-they-hiring/issues/36):
+can a pretrained embedding model + a tiny sklearn head beat the current
+`qwen2.5:1.5b` LLM few-shot classifier (#35) on the 1381 hand-labelled titles?
+
+Produced by `scripts/embed_classify_experiment.py`. Reproduce with:
+
+```bash
+uv run python scripts/embed_classify_experiment.py \
+  --input /tmp/roles-to-label.csv \
+  --l2-normalize --cv
+```
+
+Baseline to beat (qwen2.5:1.5b, chat+few-shot, full 1381 set):
+
+> **accuracy=97.8%   precision=69.8%   recall=72.5%**
+
+## Setup
+
+- 1381 unique titles, 51 positives (~3.7%), 1330 negatives.
+- Embeddings via Ollama `/api/embed` on `http://pop-os.home.lan:11434` (GPU).
+- Sklearn heads: `LogisticRegression`, `LinearSVC`. Each tried with and without
+  `class_weight="balanced"`.
+- Two eval modes per combination:
+  - **80/20 holdout** (seed=42, stratified) — matches the qwen baseline's eval.
+  - **Stratified 5-fold CV (union of OOF predictions)** — stabilises
+    precision/recall given that only ~10 positives land in a single 80/20 test
+    split.
+- Embeddings L2-normalized before fitting.
+- `nomic-embed-text` inputs are prefixed with `"classification: "` (the
+  task prefix Nomic's docs recommend for supervised classification).
+
+## Candidate embedding models
+
+| Model | Ollama disk size | Dim | Pi-viable? |
+| --- | --- | --- | --- |
+| `all-minilm`         | 46 MB  |  384 | Yes — trivial. |
+| `nomic-embed-text`   | 274 MB |  768 | Yes. |
+| `mxbai-embed-large`  | 670 MB | 1024 | Yes, tight. |
+| `bge-m3`             | 1.2 GB | 1024 | Skipped — multilingual bloat, marginal size concern on 8 GB Pi alongside qwen2.5:1.5b and Postgres. |
+
+Tiny sklearn pickles (10–20 KB each) are a rounding error on top of the
+embedding model weights.
+
+## Headline results (5-fold CV, L2-normalized, class_weight="balanced")
+
+| Embedding model    | Head | Accuracy | Precision | Recall | tp | fp | fn | Dim |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| all-minilm         | LogisticRegression | 94.28% | 38.71% | 94.12% |  48 |  76 |  3 |  384 |
+| all-minilm         | LinearSVC          | 97.39% | 60.00% | 88.24% |  45 |  30 |  6 |  384 |
+| nomic-embed-text   | LogisticRegression | 57.71% |  5.95% | 70.59% |  36 | 569 | 15 |  768 |
+| nomic-embed-text   | LinearSVC          | 60.25% |  6.32% | 70.59% |  36 | 534 | 15 |  768 |
+| mxbai-embed-large  | LogisticRegression | 91.53% | 29.63% | 94.12% |  48 | 114 |  3 | 1024 |
+| mxbai-embed-large  | LinearSVC          | 96.23% | 49.45% | 88.24% |  45 |  46 |  6 | 1024 |
+
+With `class_weight="balanced"` the heads are recall-biased. Accuracy is on par
+with the baseline for the SVC variants, recall clearly beats the baseline (88%
+vs 72.5%), but precision is substantially lower.
+
+## Headline results (5-fold CV, L2-normalized, NO class balancing)
+
+| Embedding model    | Head | Accuracy | Precision | Recall | tp | fp | fn | Dim |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| all-minilm         | LogisticRegression | 96.31% |  0.00% |  0.00% |   0 |  0 | 51 |  384 |
+| **all-minilm**     | **LinearSVC**      | **97.90%** | **89.29%** | **49.02%** | **25** | **3** | **26** | **384** |
+| nomic-embed-text   | LogisticRegression | 96.31% |  0.00% |  0.00% |   0 |  0 | 51 |  768 |
+| nomic-embed-text   | LinearSVC          | 96.31% |  0.00% |  0.00% |   0 |  0 | 51 |  768 |
+| mxbai-embed-large  | LogisticRegression | 96.31% |  0.00% |  0.00% |   0 |  0 | 51 | 1024 |
+| mxbai-embed-large  | LinearSVC          | 97.39% | 82.61% | 37.25% |  19 |  4 | 32 | 1024 |
+
+LogisticRegression without class balancing collapses to the majority class on
+this ~4% positive rate. LinearSVC's hinge loss survives the imbalance.
+**all-minilm + LinearSVC (no-balance) is the precision winner.**
+
+## Precision/recall frontier (LR, no-balance, 5-fold CV, threshold swept)
+
+### all-minilm (384d, 46 MB)
+
+| Threshold | Accuracy | Precision | Recall | tp | fp | fn |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0.05 | 84.94% | 19.46% | 98.04% | 50 | 207 |  1 |
+| 0.10 | 94.42% | 39.34% | 94.12% | 48 |  74 |  3 |
+| 0.15 | 96.74% | 54.69% | 68.63% | 35 |  29 | 16 |
+| **0.20** | **97.47%** | **73.53%** | **49.02%** | **25** | **9** | **26** |
+| 0.25 | 97.18% | 80.00% | 31.37% | 16 |   4 | 35 |
+| 0.30 | 96.67% | 72.73% | 15.69% |  8 |   3 | 43 |
+
+### mxbai-embed-large (1024d, 670 MB)
+
+| Threshold | Accuracy | Precision | Recall | tp | fp | fn |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0.05 | 83.71% | 18.25% | 98.04% | 50 | 224 |  1 |
+| 0.10 | 94.13% | 37.70% | 90.20% | 46 |  76 |  5 |
+| 0.15 | 96.74% | 54.84% | 66.67% | 34 |  28 | 17 |
+| 0.20 | 96.81% | 62.96% | 33.33% | 17 |  10 | 34 |
+
+### nomic-embed-text (768d, 274 MB)
+
+Collapses to predict-all-zero at every threshold tested. Across the whole
+sweep the best positive call is 5 false positives, 0 true positives. **This
+embedding is not useful for the task**, with or without the recommended
+`classification:` prefix.
+
+## Comparison vs qwen2.5:1.5b baseline
+
+| Configuration | Accuracy | Precision | Recall | Notes |
+| --- | ---: | ---: | ---: | --- |
+| **Baseline** qwen2.5:1.5b few-shot | **97.8%** | **69.8%** | **72.5%** | 1.5 B-parameter chat model, ~60 s to classify 1381 titles. |
+| all-minilm + LinearSVC (no-balance, CV) | 97.9% | **89.3%** | 49.0% | **Precision +19.5 pp**, recall −23.5 pp. |
+| all-minilm + LR, thr=0.20 (no-bal, CV) | 97.5% | 73.5% | 49.0% | Precision +3.7 pp, recall −23.5 pp. |
+| all-minilm + LinearSVC (balanced, CV) | 97.4% | 60.0% | **88.2%** | Precision −9.8 pp, recall +15.7 pp. |
+| mxbai-embed-large + LinearSVC (no-balance, CV) | 97.4% | 82.6% | 37.3% | Precision +12.8 pp, recall −35.2 pp. |
+
+## Interpretation
+
+- `all-minilm` (46 MB, 384-dim) is the clear winner among the three candidates.
+  `mxbai-embed-large` is strictly worse despite being 14× larger, and
+  `nomic-embed-text` is non-functional for this task in any configuration we
+  tested.
+- **The embedding approach can't match the baseline on both metrics
+  simultaneously.** At every operating point the precision-recall curve stays
+  Pareto-below the LLM baseline: we can cleanly beat it on one axis but not
+  both at once.
+  - Maximise precision (no class balancing + SVC): 89% precision at 49% recall
+    — much stricter classifier than the baseline.
+  - Maximise recall (balanced SVC): 88% recall at 60% precision — much noisier
+    classifier than the baseline.
+- The interesting operating point is *where the overall F1 is best* — which
+  for all-minilm falls around the balanced-SVC result (F1 ≈ 0.71). The LLM
+  baseline's F1 is ≈ 0.71 too. **The two approaches are roughly F1-equivalent,
+  with different operating-point tradeoffs.**
+
+## Pi viability
+
+`all-minilm` at 46 MB is free real-estate on the Pi compared to the current
+`qwen2.5:1.5b` at ~940 MB. Inference cost is negligible (embedding is a
+single forward pass through a ~22 M-parameter bi-encoder; on pop-os GPU we
+measured ~190 titles/s, which is CPU-bound on the Pi but still faster than
+the current LLM path's ~16 titles/s). The sklearn head pickle is ~15 KB.
+
+So Pi-wise: yes, easily. The bottleneck is quality, not cost.
+
+## Recommendation: don't ship as a straight replacement
+
+- The current qwen2.5:1.5b classifier at 69.8% precision / 72.5% recall is
+  Pareto-optimal among the configurations we tested — no embedding variant
+  dominates it on both metrics.
+- 51 positive labels is tight for a 384-to-1024-dim classifier. The Pareto gap
+  vs the LLM might close with 2–3× more labels, but that's a research bet.
+- Where the embedding approach **is** interesting is as a **fast pre-filter**:
+  the balanced variant catches 88% of positives with 60% precision in
+  sub-millisecond time per title. A candidate architecture would run the
+  embedding head first and only send titles it marks `yes` to the LLM for a
+  precision check. That would cut LLM calls on the negative class by 98%
+  (1300/1330) while only missing ~6/51 positives — worth a follow-up
+  experiment but out of scope for this PR.
+
+### Next steps if we want to pursue this
+
+1. Collect more labels (target: 200+ positives) before re-running.
+2. Try the two-stage pipeline (embedding screen → LLM verify) against the
+   baseline on latency + accuracy.
+3. Revisit `nomic-embed-text` with instruct-formatted input — the current
+   failure mode is suspicious enough that it warrants a closer look, but
+   all-minilm already covers the space.
+
+## Artifacts
+
+- Script: [`scripts/embed_classify_experiment.py`](embed_classify_experiment.py)
+- Cached embeddings and classifier pickles: `scripts/cache/*.npz`, `scripts/cache/*.pkl`
+- Raw JSON results: `scripts/cache/results.json`

--- a/uv.lock
+++ b/uv.lock
@@ -89,10 +89,12 @@ dependencies = [
 dev = [
     { name = "aiosqlite" },
     { name = "httpx" },
+    { name = "numpy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
     { name = "ruff" },
+    { name = "scikit-learn" },
 ]
 
 [package.dev-dependencies]
@@ -110,6 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "numpy", marker = "extra == 'dev'", specifier = ">=2.4.4" },
     { name = "playwright", specifier = ">=1.49" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -117,6 +120,7 @@ requires-dist = [
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.34" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "scikit-learn", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
@@ -339,6 +343,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +400,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]
@@ -655,6 +697,63 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -695,6 +794,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Experimental eval for [#36](https://github.com/maciej-makowski/are-they-hiring/issues/36): can an Ollama embedding + sklearn head beat the current `qwen2.5:1.5b` few-shot LLM classifier (baseline: **97.8% accuracy / 69.8% precision / 72.5% recall**) on the 1381 hand-labelled titles?

**TL;DR: no embedding variant strictly dominates the baseline.** The LLM classifier sits on the Pareto frontier — every embedding configuration trades precision for recall or vice versa. Full write-up in [`scripts/embed_classify_results.md`](scripts/embed_classify_results.md).

### Results (5-fold CV, L2-normalized)

| Combination | Acc | Prec | Rec |
| --- | ---: | ---: | ---: |
| **qwen2.5:1.5b few-shot (baseline)** | **97.8%** | **69.8%** | **72.5%** |
| all-minilm + LinearSVC no-balance     | 97.9% | 89.3% | 49.0% |
| all-minilm + LinearSVC balanced       | 97.4% | 60.0% | 88.2% |
| all-minilm + LR thr=0.20 (no-balance) | 97.5% | 73.5% | 49.0% |
| mxbai-embed-large + LinearSVC no-bal  | 97.4% | 82.6% | 37.3% |
| nomic-embed-text (any variant)        | collapses or predicts all-zero |

- **Best precision:** `all-minilm + LinearSVC (no class_weight)` — 89.3% precision, but only 49% recall.
- **Best recall:** `all-minilm + LinearSVC (balanced)` — 88.2% recall, but 60% precision.
- **Nearest-to-baseline:** `all-minilm + LR thr=0.20` — 73.5% precision, 49% recall. Matches precision, loses 23 pp of recall.

### Pi viability

- `all-minilm` is 46 MB (vs 940 MB for qwen2.5:1.5b) and embeds ~190 titles/s on GPU. Classifier pickle is ~15 KB. Free real-estate on the Pi.
- `mxbai-embed-large` is 670 MB, strictly worse on this dataset than `all-minilm`.
- `nomic-embed-text` is unusable here, prefix or no prefix.

### Recommendation: don't ship as a straight swap

The baseline is Pareto-optimal across the eval points we tested. The interesting follow-up — which this prototype doesn't implement — is a **two-stage pipeline**: run the cheap balanced-SVC head as a pre-filter, then send the ~3% it flags `yes` to the LLM for a precision check. That would cut ~98% of negative-class LLM calls while retaining the baseline's precision. Worth opening a follow-up issue if we want to pursue it.

### What changed

- `scripts/embed_classify_experiment.py` — new (embeds titles, trains LR + SVC heads with/without class_weight, does 80/20 + 5-fold CV + threshold sweep, caches both embeddings and fitted classifiers).
- `scripts/embed_classify_results.md` — new (full results table + recommendation).
- `.gitignore` — ignore regenerable `scripts/cache/`.
- `pyproject.toml` / `uv.lock` — add `scikit-learn` and `numpy` as dev deps.

No production code (`src/`, `Containerfile.ollama`) touched.

## Test plan

- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run ruff format --check src/ tests/ scripts/` — clean
- [x] `make test` — 77 integration tests pass (unchanged, nothing to regress)
- [x] Pre-commit hooks pass on the commit (`ruff check`, `ruff format`, integration tests)
- [x] Script runs end-to-end against pop-os Ollama; cache round-trips correctly (second run hits cache, no re-embedding)

### How to reproduce

Ground truth CSV needs to be at `/tmp/roles-to-label.csv` (1381 rows, `title` + `your_label` columns). Then:

```
uv run python scripts/embed_classify_experiment.py --l2-normalize --cv
```

Default Ollama host is `http://pop-os.home.lan:11434`. Override with `--ollama-host http://localhost:11435` if needed. The script will pull any missing embedding models automatically.

_Not intended for merge — if we act on the recommendation, this would motivate a separate integration PR (or a close for #36)._