### PR TITLE
feat(about): drop six-companies caveat, add meta self-disclosure

### DIFF
--- a/src/web/templates/about.html
+++ b/src/web/templates/about.html
@@ -58,10 +58,6 @@
             cases.
         </li>
         <li>
-            Only six companies. A broader sample would be more convincing,
-            but also more work to maintain.
-        </li>
-        <li>
             This is not a prediction market or a serious forecast. It is a
             countdown with a scoreboard.
         </li>
@@ -74,6 +70,13 @@
         Contributions are welcome &mdash; see
         <a href="https://github.com/maciej-makowski/are-they-hiring/blob/master/AGENTS.md" target="_blank" rel="noopener">AGENTS.md</a>
         for the conventions the repo follows.
+    </p>
+
+    <h2>One more thing</h2>
+    <p>
+        Full disclosure: every line of this site's code was written with AI
+        assistance. The tracker was built by exactly the technology it is
+        tracking.
     </p>
 </section>
 {% endblock %}

--- a/src/web/templates/about.html
+++ b/src/web/templates/about.html
@@ -75,8 +75,7 @@
     <h2>One more thing</h2>
     <p>
         Full disclosure: every line of this site's code was written with AI
-        assistance. The tracker was built by exactly the technology it is
-        tracking.
+        assistance. So maybe Dario was right all along&hellip;
     </p>
 </section>
 {% endblock %}


### PR DESCRIPTION
Two small copy tweaks to \`src/web/templates/about.html\` following review of #40:

1. **Remove the "Only six companies" caveat.** The six tracked labs are the ones with the loudest AI-replaces-engineers marketing; apologising for the sample size undercuts the framing.
2. **Add a "One more thing" section** disclosing that every line of the site's code was written with AI assistance. The site tracking whether AI replaces software engineers was, itself, built by AI. That's the joke.

Copy is deadpan; no tone shift from the rest of the page.

## Test plan

- [x] \`uv run pytest tests/integration/\` — 29 \`test_ui_states.py\` tests pass (including the about-page ones from #40).
- [x] \`uv run ruff check src/ tests/\` + \`ruff format --check\` — clean.

Follows #40.