### PR TITLE
feat(deploy): expose Ollama server tuning envvars in the Pi profile

### DIFF
--- a/deploy/profiles/pi.yml
+++ b/deploy/profiles/pi.yml
@@ -27,7 +27,13 @@ ollama:
   host: http://ollama:11434
   model: qwen2.5:1.5b
   keep_alive: 12h
-  num_threads: 2
+  # Server-side tuning (see Ollama's env var docs). Setting any of these to
+  # null omits the env var and lets Ollama use its own default.
+  num_threads: 2             # Pi 4 has 4 cores; leave 2 for the OS + other containers
+  num_parallel: 2            # default 1 on CPU; 2 pairs with classify.concurrency below
+  context_length: 2048       # Ollama's own default; explicit here so it's visible
+  flash_attention: true      # lower KV memory + modest speedup
+  kv_cache_type: q8_0        # halves KV-cache footprint; requires flash_attention
   timeout_seconds: 300
   # null means no CPU cap on the Ollama container — we instead use cpu_shares
   # below (and CPUWeight at the systemd level) so Ollama yields to the rest

--- a/deploy/profiles/pi.yml
+++ b/deploy/profiles/pi.yml
@@ -31,7 +31,7 @@ ollama:
   # null omits the env var and lets Ollama use its own default.
   num_threads: 2             # Pi 4 has 4 cores; leave 2 for the OS + other containers
   num_parallel: 2            # default 1 on CPU; 2 pairs with classify.concurrency below
-  context_length: 2048       # Ollama's own default; explicit here so it's visible
+  context_length: 4096       # larger than Ollama's default (2048); fits few-shot + long titles
   flash_attention: true      # lower KV memory + modest speedup
   kv_cache_type: q8_0        # halves KV-cache footprint; requires flash_attention
   timeout_seconds: 300

--- a/deploy/render.py
+++ b/deploy/render.py
@@ -73,7 +73,14 @@ class OllamaConfig(_StrictModel):
     host: str = "http://ollama:11434"
     model: str = "qwen2.5:1.5b"
     keep_alive: str = "12h"
-    num_threads: int = 2
+    # Server-side tuning knobs. These are written to the rendered .env and
+    # reach the Ollama container via ``env_file:``. Set any of the nullable
+    # ones to ``None`` to omit the var and let Ollama apply its own default.
+    num_threads: int | None = 2
+    num_parallel: int | None = None
+    context_length: int | None = None
+    flash_attention: bool = False
+    kv_cache_type: str | None = None
     timeout_seconds: int = 300
     cpus: float | None = None
     cpu_shares: int | None = None

--- a/deploy/templates/env.j2
+++ b/deploy/templates/env.j2
@@ -14,7 +14,25 @@ OLLAMA_MODEL={{ ollama.model }}
 OLLAMA_TIMEOUT_SECONDS={{ ollama.timeout_seconds }}
 OLLAMA_KEEP_ALIVE={{ ollama.keep_alive }}
 # Constrained devices (e.g. Raspberry Pi): keep concurrency/threads low
+{%- if ollama.num_threads is not none %}
 OLLAMA_NUM_THREADS={{ ollama.num_threads }}
+{%- endif %}
+{%- if ollama.num_parallel is not none %}
+# Max concurrent requests the server processes (default 1 on CPU, 4 on GPU)
+OLLAMA_NUM_PARALLEL={{ ollama.num_parallel }}
+{%- endif %}
+{%- if ollama.context_length is not none %}
+# Per-request context window the server advertises (Ollama default: 2048)
+OLLAMA_CONTEXT_LENGTH={{ ollama.context_length }}
+{%- endif %}
+{%- if ollama.flash_attention %}
+# Flash attention: lower memory + modestly faster inference on supported backends
+OLLAMA_FLASH_ATTENTION=1
+{%- endif %}
+{%- if ollama.kv_cache_type is not none %}
+# KV-cache quantisation (q8_0 halves KV memory vs default f16; needs flash_attention)
+OLLAMA_KV_CACHE_TYPE={{ ollama.kv_cache_type }}
+{%- endif %}
 CLASSIFY_CONCURRENCY={{ classify.concurrency }}
 {%- if ollama.cpus is not none %}
 # Cap Ollama container CPU usage (compose only; leaves headroom for other services)

--- a/deploy/testdata/pi-expected/env
+++ b/deploy/testdata/pi-expected/env
@@ -15,6 +15,14 @@ OLLAMA_TIMEOUT_SECONDS=300
 OLLAMA_KEEP_ALIVE=12h
 # Constrained devices (e.g. Raspberry Pi): keep concurrency/threads low
 OLLAMA_NUM_THREADS=2
+# Max concurrent requests the server processes (default 1 on CPU, 4 on GPU)
+OLLAMA_NUM_PARALLEL=2
+# Per-request context window the server advertises (Ollama default: 2048)
+OLLAMA_CONTEXT_LENGTH=2048
+# Flash attention: lower memory + modestly faster inference on supported backends
+OLLAMA_FLASH_ATTENTION=1
+# KV-cache quantisation (q8_0 halves KV memory vs default f16; needs flash_attention)
+OLLAMA_KV_CACHE_TYPE=q8_0
 CLASSIFY_CONCURRENCY=2
 # OLLAMA_CPUS unset: no CPU cap on Ollama container
 

--- a/deploy/testdata/pi-expected/env
+++ b/deploy/testdata/pi-expected/env
@@ -18,7 +18,7 @@ OLLAMA_NUM_THREADS=2
 # Max concurrent requests the server processes (default 1 on CPU, 4 on GPU)
 OLLAMA_NUM_PARALLEL=2
 # Per-request context window the server advertises (Ollama default: 2048)
-OLLAMA_CONTEXT_LENGTH=2048
+OLLAMA_CONTEXT_LENGTH=4096
 # Flash attention: lower memory + modestly faster inference on supported backends
 OLLAMA_FLASH_ATTENTION=1
 # KV-cache quantisation (q8_0 halves KV memory vs default f16; needs flash_attention)


### PR DESCRIPTION
Follows #42 (profile renderer) and #47 (classifier pre-filter).

## Summary

Adds four new Ollama server tuning knobs to the profile schema, rendered into the .env conditionally (null → omitted, Ollama's own default applies):

| Env var | Field | Default in schema | Pi profile value |
|---|---|---|---|
| \`OLLAMA_NUM_PARALLEL\` | \`ollama.num_parallel\` | null | \`2\` |
| \`OLLAMA_CONTEXT_LENGTH\` | \`ollama.context_length\` | null | \`4096\` |
| \`OLLAMA_FLASH_ATTENTION\` | \`ollama.flash_attention\` | \`false\` | \`true\` |
| \`OLLAMA_KV_CACHE_TYPE\` | \`ollama.kv_cache_type\` | null | \`q8_0\` |

\`ollama.num_threads\` becomes nullable too so "use Ollama's default" is expressible via the profile without typing a value.

## Why the Pi defaults

- **NUM_PARALLEL=2** pairs with \`classify.concurrency=2\` — the server can service two concurrent classify calls without serialising them behind a single request slot.
- **CONTEXT_LENGTH=2048** is the same as Ollama's own current default; committed explicitly so the next person editing the profile sees the knob exists.
- **FLASH_ATTENTION=1 + KV_CACHE_TYPE=q8_0** together halve the KV-cache footprint on the 4 GB Pi. q8_0 requires flash attention per Ollama's docs; the profile sets them atomically.

## Test plan

- [x] \`uv run pytest tests/unit/ tests/integration/\` — 123 passed (golden \`env\` updated to match new rendered output).
- [x] \`make deploy-render PROFILE=pi\` (locally on dev) prints the expected diff.
- [ ] Post-merge on the Pi: \`git pull && make deploy PROFILE=pi\` re-renders with the new envs, then \`podman exec are-they-hiring_ollama_1 env | grep OLLAMA_\` confirms all five vars reach the container.