### PR TITLE
feat(deploy/cloudflared): make install-cloudflared target + QUIC sysctl drop-in (#55, #56)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-e2e migrate revision lint lint-fix build build-all build-container-web build-container-scraper build-container-ollama run clean test-env-up test-env-down fetch classify reclassify retrain-prefilter eval-prefilter dev install uninstall install-compose uninstall-compose deploy deploy-render
+.PHONY: test test-e2e migrate revision lint lint-fix build build-all build-container-web build-container-scraper build-container-ollama run clean test-env-up test-env-down fetch classify reclassify retrain-prefilter eval-prefilter dev install uninstall install-compose uninstall-compose deploy deploy-render install-cloudflared
 
 test:
 	uv run pytest tests/unit/ tests/integration/ -v
@@ -137,3 +137,11 @@ uninstall-compose:
 	rm -f $(HOME)/.config/systemd/user/are-they-hiring-compose.service
 	systemctl --user daemon-reload
 	@echo "Service removed. Data volume, compose file, and .env preserved."
+
+install-cloudflared:
+	@if [ -z "$(HOST)" ]; then echo "Usage: make install-cloudflared HOST=user@host"; exit 2; fi
+	@echo "### staging sysctl drop-in for QUIC UDP buffers ###"
+	scp deploy/cloudflared/99-cloudflared-quic.conf $(HOST):/tmp/_cf-quic.conf
+	ssh $(HOST) 'sudo install -m 644 -o root -g root /tmp/_cf-quic.conf /etc/sysctl.d/99-cloudflared-quic.conf && rm /tmp/_cf-quic.conf && sudo sysctl --system >/dev/null && printf "rmem_max=%s\nwmem_max=%s\n" "$$(cat /proc/sys/net/core/rmem_max)" "$$(cat /proc/sys/net/core/wmem_max)"'
+	@echo "### ensuring cloudflared.service is installed + active ###"
+	ssh $(HOST) '[ -f /etc/cloudflared/config.yml ] || { echo "ERROR: /etc/cloudflared/config.yml missing on $(HOST). Follow the Cloudflare Tunnel setup recipe in README before running this target."; exit 2; }; [ -f /etc/systemd/system/cloudflared.service ] || sudo cloudflared service install; sudo systemctl daemon-reload && sudo systemctl enable cloudflared && sudo systemctl restart cloudflared && sudo systemctl is-active cloudflared'

--- a/README.md
+++ b/README.md
@@ -323,20 +323,24 @@ ingress:
   - service: http_status:404
 EOF
 
-# 6. Install + enable the systemd service
-sudo cloudflared service install
-sudo systemctl daemon-reload
-sudo systemctl enable --now cloudflared
+# 6. Install + enable the systemd service, plus the QUIC UDP-buffer sysctl tune.
+#    Runs from your dev machine; idempotent — safe to re-run after a binary upgrade.
+make install-cloudflared HOST=cfiet@<pi-ip>
 
 # 7. Verify
 sudo systemctl is-active cloudflared       # → active
 curl -I https://aretheyhiring.maciej.dev/   # → 200
 ```
 
+`make install-cloudflared` does two host-config bits that aren't worth doing by hand on every cutover:
+
+1. Drops [`deploy/cloudflared/99-cloudflared-quic.conf`](deploy/cloudflared/99-cloudflared-quic.conf) into `/etc/sysctl.d/` and runs `sudo sysctl --system`. Lifts `net.core.{rmem,wmem}_max` to 7 MiB so cloudflared's QUIC connections don't hit the kernel's UDP-buffer ceiling. Without this, cloudflared logs a soft warning on startup and QUIC throughput is throttled under load. Reference: [quic-go UDP buffer sizes](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes).
+2. Runs `sudo cloudflared service install` (skipped if `/etc/systemd/system/cloudflared.service` already exists), then `daemon-reload` + `enable` + `restart`. The target refuses to run if `/etc/cloudflared/config.yml` is missing — set up steps 1–5 first.
+
 **Two gotchas worth remembering:**
 
 - **`credentials-file:` must point at `/etc/cloudflared/...`**, not `~/.cloudflared/...`. The system service runs as root and reads from `/etc`. If you skip step 5 and only have the user-scope copy, the service starts but can't authenticate.
-- **Run `sudo cloudflared service install` after** the config + creds are in `/etc/cloudflared/`. The installer reads them at install time and bails out otherwise.
+- **Run step 6 after** the config + creds are in `/etc/cloudflared/`. The installer reads them at install time and bails out otherwise — same applies to `make install-cloudflared`.
 
 **Recovery on a reinstalled Pi:** if the host was reflashed but the tunnel record still exists at Cloudflare (visible via `cloudflared tunnel list` once authed in step 2), you can skip step 3 — `cloudflared tunnel create` will fail "already exists" and the existing UUID + JSON cred can be re-staged into `/etc/cloudflared`. DNS routing (step 4) is also idempotent. We did exactly this when 192.168.1.2 got rebuilt.
 

--- a/deploy/cloudflared/99-cloudflared-quic.conf
+++ b/deploy/cloudflared/99-cloudflared-quic.conf
@@ -1,0 +1,19 @@
+# Increase UDP socket buffer sizes for cloudflared's QUIC connections.
+#
+# cloudflared logs a soft warning on startup when net.core.rmem_max is below
+# what quic-go wants (~7 MiB):
+#
+#   failed to sufficiently increase receive buffer size
+#   (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB)
+#
+# Tunnel works without this; under high QPS QUIC throughput is slightly
+# lower than ideal because the kernel caps UDP buffers smaller than quic-go
+# requested. Reference: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+#
+# Drop in via:
+#   sudo install -m 644 deploy/cloudflared/99-cloudflared-quic.conf /etc/sysctl.d/
+#   sudo sysctl --system
+#
+# (Or: make install-cloudflared HOST=user@host)
+net.core.rmem_max=7340032
+net.core.wmem_max=7340032


### PR DESCRIPTION
## Summary

Closes #55 and #56 in one tight PR. After the manual one-time tunnel setup recipe in the README (`cloudflared login`, `tunnel create`, DNS route, creds staged into `/etc/cloudflared/`), one command handles the bits worth scripting:

\`\`\`bash
make install-cloudflared HOST=user@host
\`\`\`

It does:

1. **Stages [\`deploy/cloudflared/99-cloudflared-quic.conf\`](deploy/cloudflared/99-cloudflared-quic.conf) into \`/etc/sysctl.d/\`** and runs \`sudo sysctl --system\`. Lifts \`net.core.{rmem,wmem}_max\` to 7 MiB so cloudflared's QUIC connections don't hit the kernel's UDP-buffer ceiling (default ~208 KiB → 7 MiB). Reference: [quic-go UDP buffer sizes](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes). This is the #56 fix.

2. **Runs \`sudo cloudflared service install\`** (skipped if the unit already exists), then \`daemon-reload\` + \`enable\` + \`restart\` + \`is-active\` check. Idempotent — safe to re-run after a binary upgrade. This is the install-target half of #55.

Refuses to run if \`/etc/cloudflared/config.yml\` is missing, so users go through the full setup recipe first.

## On #55: why no committed unit file

The original issue proposed checking in a hand-rolled \`cloudflared.service\`. That ended up being the wrong shape: \`sudo cloudflared service install\` already lays down the right unit on the host with the right binary path, dependencies, and any future tunables shipped by the cloudflared package. Automating the *invocation* (plus the sysctl tune), not the file content, is the actual reproducibility win — and avoids the unit drifting out of sync with whatever cloudflared's installer wants.

## Live test

Ran \`make install-cloudflared HOST=cfiet@192.168.1.3\` against the Pi 5 (where cloudflared is currently serving prod via the migration done in #53):

- Sysctl applied: \`rmem_max=wmem_max=7340032\`
- \`cloudflared.service\` active after restart
- Public probe \`https://aretheyhiring.maciej.dev/\` returns 200
- 4 QUIC connections re-registered with Cloudflare's edge

## Test plan

- [x] \`make install-cloudflared\` against a host with cloudflared already installed (Pi 5) — works, idempotent
- [x] Pre-commit clean (ruff, ruff format, unit + integration tests)
- [ ] Apply on a fresh host where \`/etc/cloudflared/config.yml\` doesn't exist — should error with the documented hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)